### PR TITLE
Improve success message accessibility

### DIFF
--- a/site/_includes/form.njk
+++ b/site/_includes/form.njk
@@ -26,13 +26,15 @@
     </engca-form-field>
     <input type="submit" id="mc-embedded-subscribe" name="subscribe" data-theme="orange" value="{{ 'form-submit-button' | i18n }}">
   </form>
-  <engca-form-success hidden>
+
+  <engca-form-success aria-live="polite"></engca-form-success>
+  <template id="form-success-msg">
     <p>
       <strong>{{ 'form-success-message' | i18n }}</strong>
     </p>
     <img width="75" height="75" src="/public/images/check-circle.svg" aria-hidden="true">
     <p>{{ 'form-success-message-2' | i18n }}</p>
-  </engca-form-success>
+  </template>
 </engca-join-convo-form>
 <p>
   {{ 'form-privacy-message' | i18n | safe }}

--- a/src/css/form.css
+++ b/src/css/form.css
@@ -84,7 +84,7 @@ input[type="email"][aria-invalid="true"]:focus {
   outline-color: currentColor !important;
 }
 
-engca-form-success {
+engca-form-success:not(:empty) {
   text-align: center;
   background-color: var(--blue);
   padding: 1rem;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,10 +1,23 @@
+/* Accessibility note.
+ *
+ * Currently, the success and error messages for this form take 
+ * two different approaches to accessibility.
+ * 
+ * The success message uses an "aria-live" region, which announces 
+ * itself whenever contents are updated.
+ * 
+ * The error messages use hide-and-show techniques with the "hidden" 
+ * attribute, auto-focus, and other aria attributes.
+ */ 
+
 class JoinConversationForm extends window.HTMLElement {
   connectedCallback() {
     const form = this.querySelector("form");
     const emailInput = form.querySelector("input[type='email']");
     const emailError = form.querySelector("engca-form-error#emailError");
     const apiError = form.querySelector("engca-form-error#apiError");
-    const success = this.querySelector("engca-form-success");
+    const successLiveArea = this.querySelector("engca-form-success");
+    const successTemplate = this.querySelector("template#form-success-msg");
 
     form.addEventListener("submit", async (e) => {
       e.preventDefault();
@@ -41,9 +54,9 @@ class JoinConversationForm extends window.HTMLElement {
       });
 
       if (response.ok) {
+        const successMessage = successTemplate.content;
+        successLiveArea.appendChild(successMessage);
         form.setAttribute("hidden", "");
-        success.removeAttribute("hidden");
-        success.focus();
       } else {
         apiError.removeAttribute("hidden");
         apiError.focus();


### PR DESCRIPTION
As described.

Converts the success message into an `aria-live` region, for better reporting to screen readers.