### PR TITLE
Small color + typography fixes

### DIFF
--- a/src/css/form.css
+++ b/src/css/form.css
@@ -28,8 +28,11 @@
   }
 }
 
+.section-standout,
+.section-standout a:not(.btn),
+section#sign-up,
 section#sign-up h2 {
-  color: var(--white);
+  color: var(--off-white);
 }
 
 .form-flex {

--- a/src/css/homepage.css
+++ b/src/css/homepage.css
@@ -47,8 +47,11 @@ section#partners {
 }
 
 section#partners p {
-  max-width: 45rem;
   margin-block-end: 5.4rem;
+}
+
+[lang="en"] section#partners p {
+  max-width: 45rem;
 }
 
 engca-partner-flex {

--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -23,6 +23,8 @@ html {
     sans-serif !important;
 }
 
+
+
 /* Custom element tags without JS shall default to the following. */
 :where(:not(:defined)){
   display: block;
@@ -54,6 +56,7 @@ html {
   @media screen and (min-width: 992px) {
     display: flex;
     justify-content: space-between;
+    align-items: center;
   }
 }
 
@@ -182,7 +185,8 @@ section h2 {
     display: none;
   }
   li a,
-  li a:hover {
+  li a:hover,
+  li a:focus {
     color: #fff;
   }
 }


### PR DESCRIPTION
@xjensen Please reassign if you're no longer working on this project... this is in response to some questions from Erica.

### Changes

- Text on dark backgrounds is now off-white, as per the style guide
- Typographic measure (e.g. line width) of the Partners section is no longer constrained on translated pages that might have longer words
- Fixed insufficient contrast on the focus state of language switcher links