### PR TITLE
Change options for LA Fires conversations

### DIFF
--- a/scripts/translation_table_contents.py
+++ b/scripts/translation_table_contents.py
@@ -221,6 +221,28 @@ translations = {
       "zh-hant": "Los Angeles fires recovery",
       "location": "Home"
   },
+  "topic-los-angeles-fire-recovery-palisades": {
+      "en": "LA Fires: Palisades",
+      "fr": "LA Fires: Palisades",
+      "es": "LA Fires: Palisades",
+      "ko": "LA Fires: Palisades",
+      "vi": "LA Fires: Palisades",
+      "tl": "LA Fires: Palisades",
+      "zh-hans": "LA Fires: Palisades",
+      "zh-hant": "LA Fires: Palisades",
+      "location": "Home"
+  },
+  "topic-los-angeles-fire-recovery-eaton": {
+      "en": "LA Fires: Eaton",
+      "fr": "LA Fires: Eaton",
+      "es": "LA Fires: Eaton",
+      "ko": "LA Fires: Eaton",
+      "vi": "LA Fires: Eaton",
+      "tl": "LA Fires: Eaton",
+      "zh-hans": "LA Fires: Eaton",
+      "zh-hant": "LA Fires: Eaton",
+      "location": "Home"
+  },
   'valid-email-message': {
   'en': 'Please enter a valid email address.',
   'fr': 'Veuillez entrer une adresse e-mail valide.',

--- a/site/_data/i18n.js
+++ b/site/_data/i18n.js
@@ -234,6 +234,32 @@ const translations = {
         "hy": "Լոս Անջելեսի՝ հրդեհներիՑ վերականգնումը",
         "location": "Home"
     },
+    "topic-los-angeles-fire-recovery-palisades": {
+        "en": "LA Fires: Palisades",
+        "fr": "LA Fires: Palisades",
+        "es": "LA Fires: Palisades",
+        "ko": "LA Fires: Palisades",
+        "vi": "LA Fires: Palisades",
+        "tl": "LA Fires: Palisades",
+        "zh-hans": "LA Fires: Palisades",
+        "zh-hant":"LA Fires: Palisades",
+        "fa": "LA Fires: Palisades",
+        "hy": "LA Fires: Palisades",
+        "location": "Home"
+    },
+    "topic-los-angeles-fire-recovery-eaton": {
+        "en": "LA Fires: Eaton",
+        "fr": "LA Fires: Eaton",
+        "es": "LA Fires: Eaton",
+        "ko": "LA Fires: Eaton",
+        "vi": "LA Fires: Eaton",
+        "tl": "LA Fires: Eaton",
+        "zh-hans": "LA Fires: Eaton",
+        "zh-hant":"LA Fires: Eaton",
+        "fa": "LA Fires: Eaton",
+        "hy": "LA Fires: Eaton",
+        "location": "Home"
+    },
     "valid-email-message": {
         "en": "Please enter a valid email address.",
         "fr": "Veuillez entrer une adresse e-mail valide.",

--- a/site/_includes/form.njk
+++ b/site/_includes/form.njk
@@ -29,17 +29,24 @@
 
     <engca-form-field>
     <h3 class="form-title">{{ 'topics-interests-label' | i18n }}</h3>
+
     <ul class="form-checkbox-list">
       <li>
-        <input type="checkbox" class="form-check-input" id="mce-group[91023]-91023-0" name="group[91023][2]" value="Future topics" checked>
+        <input type="checkbox" class="form-check-input" id="mce-group[91023]-91023-0" name="group[91023][4]" value="LA Fires: Palisades">
         <label class="form-control-label form-checkbox-label" for="mce-group[91023]-91023-0">
-          {{ 'topic-future-topics' | i18n }}
+          {{ 'topic-los-angeles-fire-recovery-palisades' | i18n }}
         </label>
       </li>
       <li>
-        <input type="checkbox" class="form-check-input" id="mce-group[91023]-91023-1" name="group[91023][1]" value="Los Angeles fires recovery">
+        <input type="checkbox" class="form-check-input" id="mce-group[91023]-91023-1" name="group[91023][8]" value="LA Fires: Eaton">
         <label class="form-control-label form-checkbox-label" for="mce-group[91023]-91023-1">
-          {{ 'topic-los-angeles-fire-recovery' | i18n }}
+          {{ 'topic-los-angeles-fire-recovery-eaton' | i18n }}
+        </label>
+      </li>
+      <li>
+        <input type="checkbox" class="form-check-input" id="mce-group[91023]-91023-2" name="group[91023][2]" value="Future topics" checked>
+        <label class="form-control-label form-checkbox-label" for="mce-group[91023]-91023-2">
+          {{ 'topic-future-topics' | i18n }}
         </label>
       </li>
       </ul>


### PR DESCRIPTION
* Split Los Angeles fires recovery into two topics
* Has companion work done for Mailchimp
* Needs companion work done for AWS Lambda (including getting new interests values for the topics)