### PR TITLE
Text-only fires recovery page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ scripts/i18n_candidate.js
 site/es_old
 .autoenv*
 .venv*
+scripts/venv

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@web/test-runner-puppeteer": "^0.17.0",
         "axe-playwright": "^2.0.3",
         "chalk": "^5.3.0",
-        "esbuild": "^0.24.0",
+        "esbuild": "^0.25.1",
         "lightningcss": "^1.28.2",
         "markdown-it": "^14.1.0"
       }
@@ -407,9 +407,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.0.tgz",
-      "integrity": "sha512-WtKdFM7ls47zkKHFVzMz8opM7LkcsIp9amDUBIAWirg70RM71WRSjdILPsY5Uv1D42ZpUfaPILDlfactHgsRkw==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.1.tgz",
+      "integrity": "sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ==",
       "cpu": [
         "ppc64"
       ],
@@ -424,9 +424,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.0.tgz",
-      "integrity": "sha512-arAtTPo76fJ/ICkXWetLCc9EwEHKaeya4vMrReVlEIUCAUncH7M4bhMQ+M9Vf+FFOZJdTNMXNBrWwW+OXWpSew==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.1.tgz",
+      "integrity": "sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q==",
       "cpu": [
         "arm"
       ],
@@ -441,9 +441,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.0.tgz",
-      "integrity": "sha512-Vsm497xFM7tTIPYK9bNTYJyF/lsP590Qc1WxJdlB6ljCbdZKU9SY8i7+Iin4kyhV/KV5J2rOKsBQbB77Ab7L/w==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.1.tgz",
+      "integrity": "sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA==",
       "cpu": [
         "arm64"
       ],
@@ -458,9 +458,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.0.tgz",
-      "integrity": "sha512-t8GrvnFkiIY7pa7mMgJd7p8p8qqYIz1NYiAoKc75Zyv73L3DZW++oYMSHPRarcotTKuSs6m3hTOa5CKHaS02TQ==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.1.tgz",
+      "integrity": "sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw==",
       "cpu": [
         "x64"
       ],
@@ -475,9 +475,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.0.tgz",
-      "integrity": "sha512-CKyDpRbK1hXwv79soeTJNHb5EiG6ct3efd/FTPdzOWdbZZfGhpbcqIpiD0+vwmpu0wTIL97ZRPZu8vUt46nBSw==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.1.tgz",
+      "integrity": "sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ==",
       "cpu": [
         "arm64"
       ],
@@ -492,9 +492,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.0.tgz",
-      "integrity": "sha512-rgtz6flkVkh58od4PwTRqxbKH9cOjaXCMZgWD905JOzjFKW+7EiUObfd/Kav+A6Gyud6WZk9w+xu6QLytdi2OA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.1.tgz",
+      "integrity": "sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA==",
       "cpu": [
         "x64"
       ],
@@ -509,9 +509,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.0.tgz",
-      "integrity": "sha512-6Mtdq5nHggwfDNLAHkPlyLBpE5L6hwsuXZX8XNmHno9JuL2+bg2BX5tRkwjyfn6sKbxZTq68suOjgWqCicvPXA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.1.tgz",
+      "integrity": "sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A==",
       "cpu": [
         "arm64"
       ],
@@ -526,9 +526,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.0.tgz",
-      "integrity": "sha512-D3H+xh3/zphoX8ck4S2RxKR6gHlHDXXzOf6f/9dbFt/NRBDIE33+cVa49Kil4WUjxMGW0ZIYBYtaGCa2+OsQwQ==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.1.tgz",
+      "integrity": "sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww==",
       "cpu": [
         "x64"
       ],
@@ -543,9 +543,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.0.tgz",
-      "integrity": "sha512-gJKIi2IjRo5G6Glxb8d3DzYXlxdEj2NlkixPsqePSZMhLudqPhtZ4BUrpIuTjJYXxvF9njql+vRjB2oaC9XpBw==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.1.tgz",
+      "integrity": "sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ==",
       "cpu": [
         "arm"
       ],
@@ -560,9 +560,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.0.tgz",
-      "integrity": "sha512-TDijPXTOeE3eaMkRYpcy3LarIg13dS9wWHRdwYRnzlwlA370rNdZqbcp0WTyyV/k2zSxfko52+C7jU5F9Tfj1g==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.1.tgz",
+      "integrity": "sha512-jaN3dHi0/DDPelk0nLcXRm1q7DNJpjXy7yWaWvbfkPvI+7XNSc/lDOnCLN7gzsyzgu6qSAmgSvP9oXAhP973uQ==",
       "cpu": [
         "arm64"
       ],
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.0.tgz",
-      "integrity": "sha512-K40ip1LAcA0byL05TbCQ4yJ4swvnbzHscRmUilrmP9Am7//0UjPreh4lpYzvThT2Quw66MhjG//20mrufm40mA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.1.tgz",
+      "integrity": "sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ==",
       "cpu": [
         "ia32"
       ],
@@ -594,9 +594,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.0.tgz",
-      "integrity": "sha512-0mswrYP/9ai+CU0BzBfPMZ8RVm3RGAN/lmOMgW4aFUSOQBjA31UP8Mr6DDhWSuMwj7jaWOT0p0WoZ6jeHhrD7g==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.1.tgz",
+      "integrity": "sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg==",
       "cpu": [
         "loong64"
       ],
@@ -611,9 +611,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.0.tgz",
-      "integrity": "sha512-hIKvXm0/3w/5+RDtCJeXqMZGkI2s4oMUGj3/jM0QzhgIASWrGO5/RlzAzm5nNh/awHE0A19h/CvHQe6FaBNrRA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.1.tgz",
+      "integrity": "sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg==",
       "cpu": [
         "mips64el"
       ],
@@ -628,9 +628,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.0.tgz",
-      "integrity": "sha512-HcZh5BNq0aC52UoocJxaKORfFODWXZxtBaaZNuN3PUX3MoDsChsZqopzi5UupRhPHSEHotoiptqikjN/B77mYQ==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.1.tgz",
+      "integrity": "sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg==",
       "cpu": [
         "ppc64"
       ],
@@ -645,9 +645,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.0.tgz",
-      "integrity": "sha512-bEh7dMn/h3QxeR2KTy1DUszQjUrIHPZKyO6aN1X4BCnhfYhuQqedHaa5MxSQA/06j3GpiIlFGSsy1c7Gf9padw==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.1.tgz",
+      "integrity": "sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ==",
       "cpu": [
         "riscv64"
       ],
@@ -662,9 +662,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.0.tgz",
-      "integrity": "sha512-ZcQ6+qRkw1UcZGPyrCiHHkmBaj9SiCD8Oqd556HldP+QlpUIe2Wgn3ehQGVoPOvZvtHm8HPx+bH20c9pvbkX3g==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.1.tgz",
+      "integrity": "sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ==",
       "cpu": [
         "s390x"
       ],
@@ -679,9 +679,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.0.tgz",
-      "integrity": "sha512-vbutsFqQ+foy3wSSbmjBXXIJ6PL3scghJoM8zCL142cGaZKAdCZHyf+Bpu/MmX9zT9Q0zFBVKb36Ma5Fzfa8xA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.1.tgz",
+      "integrity": "sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA==",
       "cpu": [
         "x64"
       ],
@@ -695,10 +695,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.1.tgz",
+      "integrity": "sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.0.tgz",
-      "integrity": "sha512-hjQ0R/ulkO8fCYFsG0FZoH+pWgTTDreqpqY7UnQntnaKv95uP5iW3+dChxnx7C3trQQU40S+OgWhUVwCjVFLvg==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.1.tgz",
+      "integrity": "sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA==",
       "cpu": [
         "x64"
       ],
@@ -713,9 +730,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.0.tgz",
-      "integrity": "sha512-MD9uzzkPQbYehwcN583yx3Tu5M8EIoTD+tUgKF982WYL9Pf5rKy9ltgD0eUgs8pvKnmizxjXZyLt0z6DC3rRXg==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.1.tgz",
+      "integrity": "sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg==",
       "cpu": [
         "arm64"
       ],
@@ -730,9 +747,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.0.tgz",
-      "integrity": "sha512-4ir0aY1NGUhIC1hdoCzr1+5b43mw99uNwVzhIq1OY3QcEwPDO3B7WNXBzaKY5Nsf1+N11i1eOfFcq+D/gOS15Q==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.1.tgz",
+      "integrity": "sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw==",
       "cpu": [
         "x64"
       ],
@@ -747,9 +764,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.0.tgz",
-      "integrity": "sha512-jVzdzsbM5xrotH+W5f1s+JtUy1UWgjU0Cf4wMvffTB8m6wP5/kx0KiaLHlbJO+dMgtxKV8RQ/JvtlFcdZ1zCPA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.1.tgz",
+      "integrity": "sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg==",
       "cpu": [
         "x64"
       ],
@@ -764,9 +781,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.0.tgz",
-      "integrity": "sha512-iKc8GAslzRpBytO2/aN3d2yb2z8XTVfNV0PjGlCxKo5SgWmNXx82I/Q3aG1tFfS+A2igVCY97TJ8tnYwpUWLCA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.1.tgz",
+      "integrity": "sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ==",
       "cpu": [
         "arm64"
       ],
@@ -781,9 +798,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.0.tgz",
-      "integrity": "sha512-vQW36KZolfIudCcTnaTpmLQ24Ha1RjygBo39/aLkM2kmjkWmZGEJ5Gn9l5/7tzXA42QGIoWbICfg6KLLkIw6yw==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.1.tgz",
+      "integrity": "sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A==",
       "cpu": [
         "ia32"
       ],
@@ -798,9 +815,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.0.tgz",
-      "integrity": "sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.1.tgz",
+      "integrity": "sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==",
       "cpu": [
         "x64"
       ],
@@ -3473,9 +3490,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.0.tgz",
-      "integrity": "sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.1.tgz",
+      "integrity": "sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3486,30 +3503,31 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.24.0",
-        "@esbuild/android-arm": "0.24.0",
-        "@esbuild/android-arm64": "0.24.0",
-        "@esbuild/android-x64": "0.24.0",
-        "@esbuild/darwin-arm64": "0.24.0",
-        "@esbuild/darwin-x64": "0.24.0",
-        "@esbuild/freebsd-arm64": "0.24.0",
-        "@esbuild/freebsd-x64": "0.24.0",
-        "@esbuild/linux-arm": "0.24.0",
-        "@esbuild/linux-arm64": "0.24.0",
-        "@esbuild/linux-ia32": "0.24.0",
-        "@esbuild/linux-loong64": "0.24.0",
-        "@esbuild/linux-mips64el": "0.24.0",
-        "@esbuild/linux-ppc64": "0.24.0",
-        "@esbuild/linux-riscv64": "0.24.0",
-        "@esbuild/linux-s390x": "0.24.0",
-        "@esbuild/linux-x64": "0.24.0",
-        "@esbuild/netbsd-x64": "0.24.0",
-        "@esbuild/openbsd-arm64": "0.24.0",
-        "@esbuild/openbsd-x64": "0.24.0",
-        "@esbuild/sunos-x64": "0.24.0",
-        "@esbuild/win32-arm64": "0.24.0",
-        "@esbuild/win32-ia32": "0.24.0",
-        "@esbuild/win32-x64": "0.24.0"
+        "@esbuild/aix-ppc64": "0.25.1",
+        "@esbuild/android-arm": "0.25.1",
+        "@esbuild/android-arm64": "0.25.1",
+        "@esbuild/android-x64": "0.25.1",
+        "@esbuild/darwin-arm64": "0.25.1",
+        "@esbuild/darwin-x64": "0.25.1",
+        "@esbuild/freebsd-arm64": "0.25.1",
+        "@esbuild/freebsd-x64": "0.25.1",
+        "@esbuild/linux-arm": "0.25.1",
+        "@esbuild/linux-arm64": "0.25.1",
+        "@esbuild/linux-ia32": "0.25.1",
+        "@esbuild/linux-loong64": "0.25.1",
+        "@esbuild/linux-mips64el": "0.25.1",
+        "@esbuild/linux-ppc64": "0.25.1",
+        "@esbuild/linux-riscv64": "0.25.1",
+        "@esbuild/linux-s390x": "0.25.1",
+        "@esbuild/linux-x64": "0.25.1",
+        "@esbuild/netbsd-arm64": "0.25.1",
+        "@esbuild/netbsd-x64": "0.25.1",
+        "@esbuild/openbsd-arm64": "0.25.1",
+        "@esbuild/openbsd-x64": "0.25.1",
+        "@esbuild/sunos-x64": "0.25.1",
+        "@esbuild/win32-arm64": "0.25.1",
+        "@esbuild/win32-ia32": "0.25.1",
+        "@esbuild/win32-x64": "0.25.1"
       }
     },
     "node_modules/escalade": {
@@ -4929,9 +4947,9 @@
       }
     },
     "node_modules/koa": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.15.3.tgz",
-      "integrity": "sha512-j/8tY9j5t+GVMLeioLaxweJiKUayFhlGqNTzf2ZGwL0ZCQijd2RLHK0SLW5Tsko8YyyqCZC2cojIb0/s62qTAg==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.0.tgz",
+      "integrity": "sha512-Afhqq0Vq3W7C+/rW6IqHVBDLzqObwZ07JaUNUEF8yCQ6afiyFE3RAy+i7V0E46XOWlH7vPWn/x0vsZwNy6PWxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@web/test-runner-puppeteer": "^0.17.0",
     "axe-playwright": "^2.0.3",
     "chalk": "^5.3.0",
-    "esbuild": "^0.24.0",
+    "esbuild": "^0.25.1",
     "lightningcss": "^1.28.2",
     "markdown-it": "^14.1.0"
   },

--- a/site/_data/i18n.js
+++ b/site/_data/i18n.js
@@ -26,6 +26,19 @@ const translations = {
         "hy": "Ծրագրի մասին"  ,
         "location": "Home"
     },
+    "los-angeles-fires-recovery": {
+        "en": "Los Angeles fires recovery",
+        "fr": "Los Angeles fires recovery",
+        "es": "Los Angeles fires recovery",
+        "ko": "Los Angeles fires recovery",
+        "vi": "Los Angeles fires recovery",
+        "tl": "Los Angeles fires recovery",
+        "zh-hans": "Los Angeles fires recovery",
+        "zh-hant": "Los Angeles fires recovery",
+        "fa": "Los Angeles fires recovery",
+        "hy": "Los Angeles fires recovery",
+        "location": "Home"
+    },
     "sign-up-now": {
         "en": "Sign up now",
         "fr": "Inscrivez-vous maintenant",

--- a/site/_includes/layout.njk
+++ b/site/_includes/layout.njk
@@ -164,6 +164,9 @@
             <li class="nav-item">
               <a class="first-level-link" href="{{ '/about' | localizedPath(locale) }}">{{ 'about-the-program' | i18n }}</a>
             </li>
+            <li class="nav-item">
+              <a class="first-level-link" href="{{ '/lafires-recovery' | localizedPath(locale) }}">{{ 'los-angeles-fires-recovery' | i18n }}</a>
+            </li>
           </ul>
         </nav>
       </div>

--- a/site/_includes/page-with-form.njk
+++ b/site/_includes/page-with-form.njk
@@ -1,0 +1,13 @@
+{% extends "layout.njk" %}
+{% block content %}
+  <div class="container m-b-lg">
+    {{ content | safe }}
+  </div>
+  <section id="sign-up">
+    <div class="container form-flex">
+      <img src="/public/images/bubble-cluster-1.svg" class="signup-cluster-1" aria-hidden="true" alt="" />
+      <img src="/public/images/bubble-cluster-2.svg" class="signup-cluster-2" aria-hidden="true" alt="" />
+      {% include "form.njk" %}
+    </div>
+  </section>
+{% endblock %}

--- a/site/en/lafires-recovery.md
+++ b/site/en/lafires-recovery.md
@@ -21,11 +21,11 @@ The State of California is bringing survivors and those impacted by the Los Ange
 
 The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
 
-[Learn more about Engaged California](/about)
-
 ### About the process
 
 Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+[Learn more about Engaged California](/about)
 
 ## What happens in each phase
 

--- a/site/en/lafires-recovery.md
+++ b/site/en/lafires-recovery.md
@@ -29,11 +29,11 @@ Engaged California is built upon deliberative democracy. It’s unlike polling, 
 
 ## What happens in each phase
 
-### Engagement opens
+### ✅ Engagement opens
 
 We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
 
-### Agenda setting
+### ➡️ Agenda setting
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 

--- a/site/en/lafires-recovery.md
+++ b/site/en/lafires-recovery.md
@@ -11,7 +11,7 @@ tags:
 ---
 # Los Angeles fires recovery
 
-*Agenda setting goes through March 31, 2025*
+*Agenda setting is happening now*
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 

--- a/site/en/lafires-recovery.md
+++ b/site/en/lafires-recovery.md
@@ -1,0 +1,72 @@
+---
+title: Los Angeles fires recovery
+description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
+layout: page
+keywords:
+  - Los Angeles
+  - fires
+  - recovery
+tags:
+  - pages
+---
+# Los Angeles fires recovery
+
+*Agenda setting goes through March 31, 2025*
+
+The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
+
+[Sign up to stay informed](/#sign-up)
+
+## Overview
+
+The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
+
+[Learn more about Engaged California](/about)
+
+### About the process
+
+Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+## What happens in each phase
+
+### Engagement opens
+
+We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
+
+### Agenda setting
+
+People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
+
+### Review 
+
+You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
+
+### Planning
+
+The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
+
+We’ll use the takeaways from agenda setting to find the right policymakers and officials to work with. We’ll also carefully plan a deliberation opportunity for each of the wildfire recovery efforts we’re focusing on in this engagement: Eaton and Palisades.
+
+This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
+
+### Deliberation
+
+You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
+
+### Reporting
+
+We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
+
+## General information
+
+* Participation is voluntary
+* You will not be paid for your time
+* You must be 18 years or older to participate
+* We will protect and keep personal information private 
+
+## Code of conduct
+
+* Everyone involved in the Engaged California process must follow a pledge of civility
+* You should be open to listening and sharing 
+* Treat each other with respect on the platform and in any follow-up chats
+* You must communicate with others respectfully 

--- a/site/en/lafires-recovery.md
+++ b/site/en/lafires-recovery.md
@@ -37,11 +37,11 @@ We announced the Los Angeles fires recovery topic on February 24, 2025. You can 
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 
-### Review 
+### ⚪️ Review 
 
 You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
 
-### Planning
+### ⚪️ Planning
 
 The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
 
@@ -49,11 +49,11 @@ We’ll use the takeaways from agenda setting to find the right policymakers and
 
 This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
 
-### Deliberation
+### ⚪️ Deliberation
 
 You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
 
-### Reporting
+### ⚪️ Reporting
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 

--- a/site/en/lafires-recovery.md
+++ b/site/en/lafires-recovery.md
@@ -57,14 +57,14 @@ You will discuss what the community needs most. You’ll reach a consensus on ho
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 
-## General information
+### General information
 
 * Participation is voluntary
 * You will not be paid for your time
 * You must be 18 years or older to participate
 * We will protect and keep personal information private 
 
-## Code of conduct
+### Code of conduct
 
 * Everyone involved in the Engaged California process must follow a pledge of civility
 * You should be open to listening and sharing 

--- a/site/en/lafires-recovery.md
+++ b/site/en/lafires-recovery.md
@@ -1,7 +1,7 @@
 ---
 title: Los Angeles fires recovery
 description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
-layout: page
+layout: page-with-form
 keywords:
   - Los Angeles
   - fires
@@ -15,7 +15,7 @@ tags:
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 
-[Sign up to stay informed](/#sign-up)
+[Sign up to stay informed](#sign-up)
 
 ## Overview
 

--- a/site/es/lafires-recovery.md
+++ b/site/es/lafires-recovery.md
@@ -21,11 +21,11 @@ The State of California is bringing survivors and those impacted by the Los Ange
 
 The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
 
-[Learn more about Engaged California](/about)
-
 ### About the process
 
 Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+[Learn more about Engaged California](/about)
 
 ## What happens in each phase
 

--- a/site/es/lafires-recovery.md
+++ b/site/es/lafires-recovery.md
@@ -29,11 +29,11 @@ Engaged California is built upon deliberative democracy. It’s unlike polling, 
 
 ## What happens in each phase
 
-### Engagement opens
+### ✅ Engagement opens
 
 We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
 
-### Agenda setting
+### ➡️ Agenda setting
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 

--- a/site/es/lafires-recovery.md
+++ b/site/es/lafires-recovery.md
@@ -11,7 +11,7 @@ tags:
 ---
 # Los Angeles fires recovery
 
-*Agenda setting goes through March 31, 2025*
+*Agenda setting is happening now*
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 

--- a/site/es/lafires-recovery.md
+++ b/site/es/lafires-recovery.md
@@ -1,0 +1,72 @@
+---
+title: Los Angeles fires recovery
+description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
+layout: page
+keywords:
+  - Los Angeles
+  - fires
+  - recovery
+tags:
+  - pages
+---
+# Los Angeles fires recovery
+
+*Agenda setting goes through March 31, 2025*
+
+The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
+
+[Sign up to stay informed](/#sign-up)
+
+## Overview
+
+The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
+
+[Learn more about Engaged California](/about)
+
+### About the process
+
+Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+## What happens in each phase
+
+### Engagement opens
+
+We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
+
+### Agenda setting
+
+People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
+
+### Review 
+
+You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
+
+### Planning
+
+The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
+
+We’ll use the takeaways from agenda setting to find the right policymakers and officials to work with. We’ll also carefully plan a deliberation opportunity for each of the wildfire recovery efforts we’re focusing on in this engagement: Eaton and Palisades.
+
+This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
+
+### Deliberation
+
+You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
+
+### Reporting
+
+We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
+
+## General information
+
+* Participation is voluntary
+* You will not be paid for your time
+* You must be 18 years or older to participate
+* We will protect and keep personal information private 
+
+## Code of conduct
+
+* Everyone involved in the Engaged California process must follow a pledge of civility
+* You should be open to listening and sharing 
+* Treat each other with respect on the platform and in any follow-up chats
+* You must communicate with others respectfully 

--- a/site/es/lafires-recovery.md
+++ b/site/es/lafires-recovery.md
@@ -37,11 +37,11 @@ We announced the Los Angeles fires recovery topic on February 24, 2025. You can 
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 
-### Review 
+### ⚪️ Review 
 
 You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
 
-### Planning
+### ⚪️ Planning
 
 The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
 
@@ -49,11 +49,11 @@ We’ll use the takeaways from agenda setting to find the right policymakers and
 
 This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
 
-### Deliberation
+### ⚪️ Deliberation
 
 You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
 
-### Reporting
+### ⚪️ Reporting
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 

--- a/site/es/lafires-recovery.md
+++ b/site/es/lafires-recovery.md
@@ -57,14 +57,14 @@ You will discuss what the community needs most. You’ll reach a consensus on ho
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 
-## General information
+### General information
 
 * Participation is voluntary
 * You will not be paid for your time
 * You must be 18 years or older to participate
 * We will protect and keep personal information private 
 
-## Code of conduct
+### Code of conduct
 
 * Everyone involved in the Engaged California process must follow a pledge of civility
 * You should be open to listening and sharing 

--- a/site/es/lafires-recovery.md
+++ b/site/es/lafires-recovery.md
@@ -1,7 +1,7 @@
 ---
 title: Los Angeles fires recovery
 description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
-layout: page
+layout: page-with-form
 keywords:
   - Los Angeles
   - fires
@@ -15,7 +15,7 @@ tags:
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 
-[Sign up to stay informed](/#sign-up)
+[Sign up to stay informed](#sign-up)
 
 ## Overview
 

--- a/site/fa/lafires-recovery.md
+++ b/site/fa/lafires-recovery.md
@@ -21,11 +21,11 @@ The State of California is bringing survivors and those impacted by the Los Ange
 
 The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
 
-[Learn more about Engaged California](/about)
-
 ### About the process
 
 Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+[Learn more about Engaged California](/about)
 
 ## What happens in each phase
 

--- a/site/fa/lafires-recovery.md
+++ b/site/fa/lafires-recovery.md
@@ -29,11 +29,11 @@ Engaged California is built upon deliberative democracy. It’s unlike polling, 
 
 ## What happens in each phase
 
-### Engagement opens
+### ✅ Engagement opens
 
 We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
 
-### Agenda setting
+### ➡️ Agenda setting
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 

--- a/site/fa/lafires-recovery.md
+++ b/site/fa/lafires-recovery.md
@@ -11,7 +11,7 @@ tags:
 ---
 # Los Angeles fires recovery
 
-*Agenda setting goes through March 31, 2025*
+*Agenda setting is happening now*
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 

--- a/site/fa/lafires-recovery.md
+++ b/site/fa/lafires-recovery.md
@@ -1,0 +1,72 @@
+---
+title: Los Angeles fires recovery
+description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
+layout: page
+keywords:
+  - Los Angeles
+  - fires
+  - recovery
+tags:
+  - pages
+---
+# Los Angeles fires recovery
+
+*Agenda setting goes through March 31, 2025*
+
+The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
+
+[Sign up to stay informed](/#sign-up)
+
+## Overview
+
+The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
+
+[Learn more about Engaged California](/about)
+
+### About the process
+
+Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+## What happens in each phase
+
+### Engagement opens
+
+We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
+
+### Agenda setting
+
+People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
+
+### Review 
+
+You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
+
+### Planning
+
+The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
+
+We’ll use the takeaways from agenda setting to find the right policymakers and officials to work with. We’ll also carefully plan a deliberation opportunity for each of the wildfire recovery efforts we’re focusing on in this engagement: Eaton and Palisades.
+
+This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
+
+### Deliberation
+
+You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
+
+### Reporting
+
+We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
+
+## General information
+
+* Participation is voluntary
+* You will not be paid for your time
+* You must be 18 years or older to participate
+* We will protect and keep personal information private 
+
+## Code of conduct
+
+* Everyone involved in the Engaged California process must follow a pledge of civility
+* You should be open to listening and sharing 
+* Treat each other with respect on the platform and in any follow-up chats
+* You must communicate with others respectfully 

--- a/site/fa/lafires-recovery.md
+++ b/site/fa/lafires-recovery.md
@@ -37,11 +37,11 @@ We announced the Los Angeles fires recovery topic on February 24, 2025. You can 
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 
-### Review 
+### ⚪️ Review 
 
 You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
 
-### Planning
+### ⚪️ Planning
 
 The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
 
@@ -49,11 +49,11 @@ We’ll use the takeaways from agenda setting to find the right policymakers and
 
 This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
 
-### Deliberation
+### ⚪️ Deliberation
 
 You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
 
-### Reporting
+### ⚪️ Reporting
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 

--- a/site/fa/lafires-recovery.md
+++ b/site/fa/lafires-recovery.md
@@ -57,14 +57,14 @@ You will discuss what the community needs most. You’ll reach a consensus on ho
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 
-## General information
+### General information
 
 * Participation is voluntary
 * You will not be paid for your time
 * You must be 18 years or older to participate
 * We will protect and keep personal information private 
 
-## Code of conduct
+### Code of conduct
 
 * Everyone involved in the Engaged California process must follow a pledge of civility
 * You should be open to listening and sharing 

--- a/site/fa/lafires-recovery.md
+++ b/site/fa/lafires-recovery.md
@@ -1,7 +1,7 @@
 ---
 title: Los Angeles fires recovery
 description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
-layout: page
+layout: page-with-form
 keywords:
   - Los Angeles
   - fires
@@ -15,7 +15,7 @@ tags:
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 
-[Sign up to stay informed](/#sign-up)
+[Sign up to stay informed](#sign-up)
 
 ## Overview
 

--- a/site/fr/lafires-recovery.md
+++ b/site/fr/lafires-recovery.md
@@ -21,11 +21,11 @@ The State of California is bringing survivors and those impacted by the Los Ange
 
 The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
 
-[Learn more about Engaged California](/about)
-
 ### About the process
 
 Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+[Learn more about Engaged California](/about)
 
 ## What happens in each phase
 

--- a/site/fr/lafires-recovery.md
+++ b/site/fr/lafires-recovery.md
@@ -29,11 +29,11 @@ Engaged California is built upon deliberative democracy. It’s unlike polling, 
 
 ## What happens in each phase
 
-### Engagement opens
+### ✅ Engagement opens
 
 We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
 
-### Agenda setting
+### ➡️ Agenda setting
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 

--- a/site/fr/lafires-recovery.md
+++ b/site/fr/lafires-recovery.md
@@ -11,7 +11,7 @@ tags:
 ---
 # Los Angeles fires recovery
 
-*Agenda setting goes through March 31, 2025*
+*Agenda setting is happening now*
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 

--- a/site/fr/lafires-recovery.md
+++ b/site/fr/lafires-recovery.md
@@ -1,0 +1,72 @@
+---
+title: Los Angeles fires recovery
+description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
+layout: page
+keywords:
+  - Los Angeles
+  - fires
+  - recovery
+tags:
+  - pages
+---
+# Los Angeles fires recovery
+
+*Agenda setting goes through March 31, 2025*
+
+The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
+
+[Sign up to stay informed](/#sign-up)
+
+## Overview
+
+The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
+
+[Learn more about Engaged California](/about)
+
+### About the process
+
+Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+## What happens in each phase
+
+### Engagement opens
+
+We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
+
+### Agenda setting
+
+People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
+
+### Review 
+
+You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
+
+### Planning
+
+The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
+
+We’ll use the takeaways from agenda setting to find the right policymakers and officials to work with. We’ll also carefully plan a deliberation opportunity for each of the wildfire recovery efforts we’re focusing on in this engagement: Eaton and Palisades.
+
+This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
+
+### Deliberation
+
+You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
+
+### Reporting
+
+We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
+
+## General information
+
+* Participation is voluntary
+* You will not be paid for your time
+* You must be 18 years or older to participate
+* We will protect and keep personal information private 
+
+## Code of conduct
+
+* Everyone involved in the Engaged California process must follow a pledge of civility
+* You should be open to listening and sharing 
+* Treat each other with respect on the platform and in any follow-up chats
+* You must communicate with others respectfully 

--- a/site/fr/lafires-recovery.md
+++ b/site/fr/lafires-recovery.md
@@ -37,11 +37,11 @@ We announced the Los Angeles fires recovery topic on February 24, 2025. You can 
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 
-### Review 
+### ⚪️ Review 
 
 You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
 
-### Planning
+### ⚪️ Planning
 
 The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
 
@@ -49,11 +49,11 @@ We’ll use the takeaways from agenda setting to find the right policymakers and
 
 This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
 
-### Deliberation
+### ⚪️ Deliberation
 
 You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
 
-### Reporting
+### ⚪️ Reporting
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 

--- a/site/fr/lafires-recovery.md
+++ b/site/fr/lafires-recovery.md
@@ -57,14 +57,14 @@ You will discuss what the community needs most. You’ll reach a consensus on ho
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 
-## General information
+### General information
 
 * Participation is voluntary
 * You will not be paid for your time
 * You must be 18 years or older to participate
 * We will protect and keep personal information private 
 
-## Code of conduct
+### Code of conduct
 
 * Everyone involved in the Engaged California process must follow a pledge of civility
 * You should be open to listening and sharing 

--- a/site/fr/lafires-recovery.md
+++ b/site/fr/lafires-recovery.md
@@ -1,7 +1,7 @@
 ---
 title: Los Angeles fires recovery
 description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
-layout: page
+layout: page-with-form
 keywords:
   - Los Angeles
   - fires
@@ -15,7 +15,7 @@ tags:
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 
-[Sign up to stay informed](/#sign-up)
+[Sign up to stay informed](#sign-up)
 
 ## Overview
 

--- a/site/hy/lafires-recovery.md
+++ b/site/hy/lafires-recovery.md
@@ -21,11 +21,11 @@ The State of California is bringing survivors and those impacted by the Los Ange
 
 The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
 
-[Learn more about Engaged California](/about)
-
 ### About the process
 
 Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+[Learn more about Engaged California](/about)
 
 ## What happens in each phase
 

--- a/site/hy/lafires-recovery.md
+++ b/site/hy/lafires-recovery.md
@@ -29,11 +29,11 @@ Engaged California is built upon deliberative democracy. It’s unlike polling, 
 
 ## What happens in each phase
 
-### Engagement opens
+### ✅ Engagement opens
 
 We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
 
-### Agenda setting
+### ➡️ Agenda setting
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 

--- a/site/hy/lafires-recovery.md
+++ b/site/hy/lafires-recovery.md
@@ -11,7 +11,7 @@ tags:
 ---
 # Los Angeles fires recovery
 
-*Agenda setting goes through March 31, 2025*
+*Agenda setting is happening now*
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 

--- a/site/hy/lafires-recovery.md
+++ b/site/hy/lafires-recovery.md
@@ -1,0 +1,72 @@
+---
+title: Los Angeles fires recovery
+description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
+layout: page
+keywords:
+  - Los Angeles
+  - fires
+  - recovery
+tags:
+  - pages
+---
+# Los Angeles fires recovery
+
+*Agenda setting goes through March 31, 2025*
+
+The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
+
+[Sign up to stay informed](/#sign-up)
+
+## Overview
+
+The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
+
+[Learn more about Engaged California](/about)
+
+### About the process
+
+Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+## What happens in each phase
+
+### Engagement opens
+
+We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
+
+### Agenda setting
+
+People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
+
+### Review 
+
+You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
+
+### Planning
+
+The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
+
+We’ll use the takeaways from agenda setting to find the right policymakers and officials to work with. We’ll also carefully plan a deliberation opportunity for each of the wildfire recovery efforts we’re focusing on in this engagement: Eaton and Palisades.
+
+This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
+
+### Deliberation
+
+You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
+
+### Reporting
+
+We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
+
+## General information
+
+* Participation is voluntary
+* You will not be paid for your time
+* You must be 18 years or older to participate
+* We will protect and keep personal information private 
+
+## Code of conduct
+
+* Everyone involved in the Engaged California process must follow a pledge of civility
+* You should be open to listening and sharing 
+* Treat each other with respect on the platform and in any follow-up chats
+* You must communicate with others respectfully 

--- a/site/hy/lafires-recovery.md
+++ b/site/hy/lafires-recovery.md
@@ -37,11 +37,11 @@ We announced the Los Angeles fires recovery topic on February 24, 2025. You can 
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 
-### Review 
+### ⚪️ Review 
 
 You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
 
-### Planning
+### ⚪️ Planning
 
 The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
 
@@ -49,11 +49,11 @@ We’ll use the takeaways from agenda setting to find the right policymakers and
 
 This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
 
-### Deliberation
+### ⚪️ Deliberation
 
 You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
 
-### Reporting
+### ⚪️ Reporting
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 

--- a/site/hy/lafires-recovery.md
+++ b/site/hy/lafires-recovery.md
@@ -57,14 +57,14 @@ You will discuss what the community needs most. You’ll reach a consensus on ho
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 
-## General information
+### General information
 
 * Participation is voluntary
 * You will not be paid for your time
 * You must be 18 years or older to participate
 * We will protect and keep personal information private 
 
-## Code of conduct
+### Code of conduct
 
 * Everyone involved in the Engaged California process must follow a pledge of civility
 * You should be open to listening and sharing 

--- a/site/hy/lafires-recovery.md
+++ b/site/hy/lafires-recovery.md
@@ -1,7 +1,7 @@
 ---
 title: Los Angeles fires recovery
 description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
-layout: page
+layout: page-with-form
 keywords:
   - Los Angeles
   - fires
@@ -15,7 +15,7 @@ tags:
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 
-[Sign up to stay informed](/#sign-up)
+[Sign up to stay informed](#sign-up)
 
 ## Overview
 

--- a/site/ko/lafires-recovery.md
+++ b/site/ko/lafires-recovery.md
@@ -21,11 +21,11 @@ The State of California is bringing survivors and those impacted by the Los Ange
 
 The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
 
-[Learn more about Engaged California](/about)
-
 ### About the process
 
 Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+[Learn more about Engaged California](/about)
 
 ## What happens in each phase
 

--- a/site/ko/lafires-recovery.md
+++ b/site/ko/lafires-recovery.md
@@ -29,11 +29,11 @@ Engaged California is built upon deliberative democracy. It’s unlike polling, 
 
 ## What happens in each phase
 
-### Engagement opens
+### ✅ Engagement opens
 
 We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
 
-### Agenda setting
+### ➡️ Agenda setting
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 

--- a/site/ko/lafires-recovery.md
+++ b/site/ko/lafires-recovery.md
@@ -11,7 +11,7 @@ tags:
 ---
 # Los Angeles fires recovery
 
-*Agenda setting goes through March 31, 2025*
+*Agenda setting is happening now*
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 

--- a/site/ko/lafires-recovery.md
+++ b/site/ko/lafires-recovery.md
@@ -1,0 +1,72 @@
+---
+title: Los Angeles fires recovery
+description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
+layout: page
+keywords:
+  - Los Angeles
+  - fires
+  - recovery
+tags:
+  - pages
+---
+# Los Angeles fires recovery
+
+*Agenda setting goes through March 31, 2025*
+
+The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
+
+[Sign up to stay informed](/#sign-up)
+
+## Overview
+
+The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
+
+[Learn more about Engaged California](/about)
+
+### About the process
+
+Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+## What happens in each phase
+
+### Engagement opens
+
+We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
+
+### Agenda setting
+
+People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
+
+### Review 
+
+You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
+
+### Planning
+
+The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
+
+We’ll use the takeaways from agenda setting to find the right policymakers and officials to work with. We’ll also carefully plan a deliberation opportunity for each of the wildfire recovery efforts we’re focusing on in this engagement: Eaton and Palisades.
+
+This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
+
+### Deliberation
+
+You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
+
+### Reporting
+
+We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
+
+## General information
+
+* Participation is voluntary
+* You will not be paid for your time
+* You must be 18 years or older to participate
+* We will protect and keep personal information private 
+
+## Code of conduct
+
+* Everyone involved in the Engaged California process must follow a pledge of civility
+* You should be open to listening and sharing 
+* Treat each other with respect on the platform and in any follow-up chats
+* You must communicate with others respectfully 

--- a/site/ko/lafires-recovery.md
+++ b/site/ko/lafires-recovery.md
@@ -37,11 +37,11 @@ We announced the Los Angeles fires recovery topic on February 24, 2025. You can 
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 
-### Review 
+### ⚪️ Review 
 
 You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
 
-### Planning
+### ⚪️ Planning
 
 The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
 
@@ -49,11 +49,11 @@ We’ll use the takeaways from agenda setting to find the right policymakers and
 
 This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
 
-### Deliberation
+### ⚪️ Deliberation
 
 You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
 
-### Reporting
+### ⚪️ Reporting
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 

--- a/site/ko/lafires-recovery.md
+++ b/site/ko/lafires-recovery.md
@@ -57,14 +57,14 @@ You will discuss what the community needs most. You’ll reach a consensus on ho
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 
-## General information
+### General information
 
 * Participation is voluntary
 * You will not be paid for your time
 * You must be 18 years or older to participate
 * We will protect and keep personal information private 
 
-## Code of conduct
+### Code of conduct
 
 * Everyone involved in the Engaged California process must follow a pledge of civility
 * You should be open to listening and sharing 

--- a/site/ko/lafires-recovery.md
+++ b/site/ko/lafires-recovery.md
@@ -1,7 +1,7 @@
 ---
 title: Los Angeles fires recovery
 description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
-layout: page
+layout: page-with-form
 keywords:
   - Los Angeles
   - fires
@@ -15,7 +15,7 @@ tags:
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 
-[Sign up to stay informed](/#sign-up)
+[Sign up to stay informed](#sign-up)
 
 ## Overview
 

--- a/site/tl/lafires-recovery.md
+++ b/site/tl/lafires-recovery.md
@@ -21,11 +21,11 @@ The State of California is bringing survivors and those impacted by the Los Ange
 
 The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
 
-[Learn more about Engaged California](/about)
-
 ### About the process
 
 Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+[Learn more about Engaged California](/about)
 
 ## What happens in each phase
 

--- a/site/tl/lafires-recovery.md
+++ b/site/tl/lafires-recovery.md
@@ -29,11 +29,11 @@ Engaged California is built upon deliberative democracy. It’s unlike polling, 
 
 ## What happens in each phase
 
-### Engagement opens
+### ✅ Engagement opens
 
 We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
 
-### Agenda setting
+### ➡️ Agenda setting
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 

--- a/site/tl/lafires-recovery.md
+++ b/site/tl/lafires-recovery.md
@@ -11,7 +11,7 @@ tags:
 ---
 # Los Angeles fires recovery
 
-*Agenda setting goes through March 31, 2025*
+*Agenda setting is happening now*
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 

--- a/site/tl/lafires-recovery.md
+++ b/site/tl/lafires-recovery.md
@@ -1,0 +1,72 @@
+---
+title: Los Angeles fires recovery
+description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
+layout: page
+keywords:
+  - Los Angeles
+  - fires
+  - recovery
+tags:
+  - pages
+---
+# Los Angeles fires recovery
+
+*Agenda setting goes through March 31, 2025*
+
+The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
+
+[Sign up to stay informed](/#sign-up)
+
+## Overview
+
+The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
+
+[Learn more about Engaged California](/about)
+
+### About the process
+
+Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+## What happens in each phase
+
+### Engagement opens
+
+We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
+
+### Agenda setting
+
+People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
+
+### Review 
+
+You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
+
+### Planning
+
+The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
+
+We’ll use the takeaways from agenda setting to find the right policymakers and officials to work with. We’ll also carefully plan a deliberation opportunity for each of the wildfire recovery efforts we’re focusing on in this engagement: Eaton and Palisades.
+
+This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
+
+### Deliberation
+
+You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
+
+### Reporting
+
+We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
+
+## General information
+
+* Participation is voluntary
+* You will not be paid for your time
+* You must be 18 years or older to participate
+* We will protect and keep personal information private 
+
+## Code of conduct
+
+* Everyone involved in the Engaged California process must follow a pledge of civility
+* You should be open to listening and sharing 
+* Treat each other with respect on the platform and in any follow-up chats
+* You must communicate with others respectfully 

--- a/site/tl/lafires-recovery.md
+++ b/site/tl/lafires-recovery.md
@@ -37,11 +37,11 @@ We announced the Los Angeles fires recovery topic on February 24, 2025. You can 
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 
-### Review 
+### ⚪️ Review 
 
 You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
 
-### Planning
+### ⚪️ Planning
 
 The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
 
@@ -49,11 +49,11 @@ We’ll use the takeaways from agenda setting to find the right policymakers and
 
 This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
 
-### Deliberation
+### ⚪️ Deliberation
 
 You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
 
-### Reporting
+### ⚪️ Reporting
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 

--- a/site/tl/lafires-recovery.md
+++ b/site/tl/lafires-recovery.md
@@ -57,14 +57,14 @@ You will discuss what the community needs most. You’ll reach a consensus on ho
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 
-## General information
+### General information
 
 * Participation is voluntary
 * You will not be paid for your time
 * You must be 18 years or older to participate
 * We will protect and keep personal information private 
 
-## Code of conduct
+### Code of conduct
 
 * Everyone involved in the Engaged California process must follow a pledge of civility
 * You should be open to listening and sharing 

--- a/site/tl/lafires-recovery.md
+++ b/site/tl/lafires-recovery.md
@@ -1,7 +1,7 @@
 ---
 title: Los Angeles fires recovery
 description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
-layout: page
+layout: page-with-form
 keywords:
   - Los Angeles
   - fires
@@ -15,7 +15,7 @@ tags:
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 
-[Sign up to stay informed](/#sign-up)
+[Sign up to stay informed](#sign-up)
 
 ## Overview
 

--- a/site/vi/lafires-recovery.md
+++ b/site/vi/lafires-recovery.md
@@ -21,11 +21,11 @@ The State of California is bringing survivors and those impacted by the Los Ange
 
 The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
 
-[Learn more about Engaged California](/about)
-
 ### About the process
 
 Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+[Learn more about Engaged California](/about)
 
 ## What happens in each phase
 

--- a/site/vi/lafires-recovery.md
+++ b/site/vi/lafires-recovery.md
@@ -29,11 +29,11 @@ Engaged California is built upon deliberative democracy. It’s unlike polling, 
 
 ## What happens in each phase
 
-### Engagement opens
+### ✅ Engagement opens
 
 We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
 
-### Agenda setting
+### ➡️ Agenda setting
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 

--- a/site/vi/lafires-recovery.md
+++ b/site/vi/lafires-recovery.md
@@ -11,7 +11,7 @@ tags:
 ---
 # Los Angeles fires recovery
 
-*Agenda setting goes through March 31, 2025*
+*Agenda setting is happening now*
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 

--- a/site/vi/lafires-recovery.md
+++ b/site/vi/lafires-recovery.md
@@ -1,0 +1,72 @@
+---
+title: Los Angeles fires recovery
+description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
+layout: page
+keywords:
+  - Los Angeles
+  - fires
+  - recovery
+tags:
+  - pages
+---
+# Los Angeles fires recovery
+
+*Agenda setting goes through March 31, 2025*
+
+The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
+
+[Sign up to stay informed](/#sign-up)
+
+## Overview
+
+The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
+
+[Learn more about Engaged California](/about)
+
+### About the process
+
+Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+## What happens in each phase
+
+### Engagement opens
+
+We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
+
+### Agenda setting
+
+People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
+
+### Review 
+
+You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
+
+### Planning
+
+The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
+
+We’ll use the takeaways from agenda setting to find the right policymakers and officials to work with. We’ll also carefully plan a deliberation opportunity for each of the wildfire recovery efforts we’re focusing on in this engagement: Eaton and Palisades.
+
+This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
+
+### Deliberation
+
+You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
+
+### Reporting
+
+We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
+
+## General information
+
+* Participation is voluntary
+* You will not be paid for your time
+* You must be 18 years or older to participate
+* We will protect and keep personal information private 
+
+## Code of conduct
+
+* Everyone involved in the Engaged California process must follow a pledge of civility
+* You should be open to listening and sharing 
+* Treat each other with respect on the platform and in any follow-up chats
+* You must communicate with others respectfully 

--- a/site/vi/lafires-recovery.md
+++ b/site/vi/lafires-recovery.md
@@ -37,11 +37,11 @@ We announced the Los Angeles fires recovery topic on February 24, 2025. You can 
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 
-### Review 
+### ⚪️ Review 
 
 You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
 
-### Planning
+### ⚪️ Planning
 
 The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
 
@@ -49,11 +49,11 @@ We’ll use the takeaways from agenda setting to find the right policymakers and
 
 This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
 
-### Deliberation
+### ⚪️ Deliberation
 
 You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
 
-### Reporting
+### ⚪️ Reporting
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 

--- a/site/vi/lafires-recovery.md
+++ b/site/vi/lafires-recovery.md
@@ -57,14 +57,14 @@ You will discuss what the community needs most. You’ll reach a consensus on ho
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 
-## General information
+### General information
 
 * Participation is voluntary
 * You will not be paid for your time
 * You must be 18 years or older to participate
 * We will protect and keep personal information private 
 
-## Code of conduct
+### Code of conduct
 
 * Everyone involved in the Engaged California process must follow a pledge of civility
 * You should be open to listening and sharing 

--- a/site/vi/lafires-recovery.md
+++ b/site/vi/lafires-recovery.md
@@ -1,7 +1,7 @@
 ---
 title: Los Angeles fires recovery
 description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
-layout: page
+layout: page-with-form
 keywords:
   - Los Angeles
   - fires
@@ -15,7 +15,7 @@ tags:
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 
-[Sign up to stay informed](/#sign-up)
+[Sign up to stay informed](#sign-up)
 
 ## Overview
 

--- a/site/zh-hans/lafires-recovery.md
+++ b/site/zh-hans/lafires-recovery.md
@@ -21,11 +21,11 @@ The State of California is bringing survivors and those impacted by the Los Ange
 
 The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
 
-[Learn more about Engaged California](/about)
-
 ### About the process
 
 Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+[Learn more about Engaged California](/about)
 
 ## What happens in each phase
 

--- a/site/zh-hans/lafires-recovery.md
+++ b/site/zh-hans/lafires-recovery.md
@@ -29,11 +29,11 @@ Engaged California is built upon deliberative democracy. It’s unlike polling, 
 
 ## What happens in each phase
 
-### Engagement opens
+### ✅ Engagement opens
 
 We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
 
-### Agenda setting
+### ➡️ Agenda setting
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 

--- a/site/zh-hans/lafires-recovery.md
+++ b/site/zh-hans/lafires-recovery.md
@@ -11,7 +11,7 @@ tags:
 ---
 # Los Angeles fires recovery
 
-*Agenda setting goes through March 31, 2025*
+*Agenda setting is happening now*
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 

--- a/site/zh-hans/lafires-recovery.md
+++ b/site/zh-hans/lafires-recovery.md
@@ -1,0 +1,72 @@
+---
+title: Los Angeles fires recovery
+description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
+layout: page
+keywords:
+  - Los Angeles
+  - fires
+  - recovery
+tags:
+  - pages
+---
+# Los Angeles fires recovery
+
+*Agenda setting goes through March 31, 2025*
+
+The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
+
+[Sign up to stay informed](/#sign-up)
+
+## Overview
+
+The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
+
+[Learn more about Engaged California](/about)
+
+### About the process
+
+Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+## What happens in each phase
+
+### Engagement opens
+
+We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
+
+### Agenda setting
+
+People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
+
+### Review 
+
+You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
+
+### Planning
+
+The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
+
+We’ll use the takeaways from agenda setting to find the right policymakers and officials to work with. We’ll also carefully plan a deliberation opportunity for each of the wildfire recovery efforts we’re focusing on in this engagement: Eaton and Palisades.
+
+This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
+
+### Deliberation
+
+You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
+
+### Reporting
+
+We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
+
+## General information
+
+* Participation is voluntary
+* You will not be paid for your time
+* You must be 18 years or older to participate
+* We will protect and keep personal information private 
+
+## Code of conduct
+
+* Everyone involved in the Engaged California process must follow a pledge of civility
+* You should be open to listening and sharing 
+* Treat each other with respect on the platform and in any follow-up chats
+* You must communicate with others respectfully 

--- a/site/zh-hans/lafires-recovery.md
+++ b/site/zh-hans/lafires-recovery.md
@@ -37,11 +37,11 @@ We announced the Los Angeles fires recovery topic on February 24, 2025. You can 
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 
-### Review 
+### ⚪️ Review 
 
 You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
 
-### Planning
+### ⚪️ Planning
 
 The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
 
@@ -49,11 +49,11 @@ We’ll use the takeaways from agenda setting to find the right policymakers and
 
 This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
 
-### Deliberation
+### ⚪️ Deliberation
 
 You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
 
-### Reporting
+### ⚪️ Reporting
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 

--- a/site/zh-hans/lafires-recovery.md
+++ b/site/zh-hans/lafires-recovery.md
@@ -57,14 +57,14 @@ You will discuss what the community needs most. You’ll reach a consensus on ho
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 
-## General information
+### General information
 
 * Participation is voluntary
 * You will not be paid for your time
 * You must be 18 years or older to participate
 * We will protect and keep personal information private 
 
-## Code of conduct
+### Code of conduct
 
 * Everyone involved in the Engaged California process must follow a pledge of civility
 * You should be open to listening and sharing 

--- a/site/zh-hans/lafires-recovery.md
+++ b/site/zh-hans/lafires-recovery.md
@@ -1,7 +1,7 @@
 ---
 title: Los Angeles fires recovery
 description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
-layout: page
+layout: page-with-form
 keywords:
   - Los Angeles
   - fires
@@ -15,7 +15,7 @@ tags:
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 
-[Sign up to stay informed](/#sign-up)
+[Sign up to stay informed](#sign-up)
 
 ## Overview
 

--- a/site/zh-hant/lafires-recovery.md
+++ b/site/zh-hant/lafires-recovery.md
@@ -21,11 +21,11 @@ The State of California is bringing survivors and those impacted by the Los Ange
 
 The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
 
-[Learn more about Engaged California](/about)
-
 ### About the process
 
 Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+[Learn more about Engaged California](/about)
 
 ## What happens in each phase
 

--- a/site/zh-hant/lafires-recovery.md
+++ b/site/zh-hant/lafires-recovery.md
@@ -29,11 +29,11 @@ Engaged California is built upon deliberative democracy. It’s unlike polling, 
 
 ## What happens in each phase
 
-### Engagement opens
+### ✅ Engagement opens
 
 We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
 
-### Agenda setting
+### ➡️ Agenda setting
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 

--- a/site/zh-hant/lafires-recovery.md
+++ b/site/zh-hant/lafires-recovery.md
@@ -11,7 +11,7 @@ tags:
 ---
 # Los Angeles fires recovery
 
-*Agenda setting goes through March 31, 2025*
+*Agenda setting is happening now*
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 

--- a/site/zh-hant/lafires-recovery.md
+++ b/site/zh-hant/lafires-recovery.md
@@ -1,0 +1,72 @@
+---
+title: Los Angeles fires recovery
+description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
+layout: page
+keywords:
+  - Los Angeles
+  - fires
+  - recovery
+tags:
+  - pages
+---
+# Los Angeles fires recovery
+
+*Agenda setting goes through March 31, 2025*
+
+The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
+
+[Sign up to stay informed](/#sign-up)
+
+## Overview
+
+The Engaged California team will work with community members from greater Los Angeles. We will focus on people from Altadena and Pacific Palisades. Your journey with Engaged California begins with discussions to navigate difficult and complex topics. You will work through differences in opinion about how to recover from the fires. At the end of this road, we’ll have identified the issues that are the most important to recovery.
+
+[Learn more about Engaged California](/about)
+
+### About the process
+
+Engaged California is built upon deliberative democracy. It’s unlike polling, voting, or town halls. Deliberative democracy empowers you to engage with your government in a new way. Engaged California is a space for you to have meaningful dialogue with others. This deepens understanding and can guide policy choices—before the choices are made.
+
+## What happens in each phase
+
+### Engagement opens
+
+We announced the Los Angeles fires recovery topic on February 24, 2025. You can sign up to get updates even when we’re in a later phase.
+
+### Agenda setting
+
+People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
+
+### Review 
+
+You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
+
+### Planning
+
+The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
+
+We’ll use the takeaways from agenda setting to find the right policymakers and officials to work with. We’ll also carefully plan a deliberation opportunity for each of the wildfire recovery efforts we’re focusing on in this engagement: Eaton and Palisades.
+
+This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
+
+### Deliberation
+
+You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
+
+### Reporting
+
+We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
+
+## General information
+
+* Participation is voluntary
+* You will not be paid for your time
+* You must be 18 years or older to participate
+* We will protect and keep personal information private 
+
+## Code of conduct
+
+* Everyone involved in the Engaged California process must follow a pledge of civility
+* You should be open to listening and sharing 
+* Treat each other with respect on the platform and in any follow-up chats
+* You must communicate with others respectfully 

--- a/site/zh-hant/lafires-recovery.md
+++ b/site/zh-hant/lafires-recovery.md
@@ -37,11 +37,11 @@ We announced the Los Angeles fires recovery topic on February 24, 2025. You can 
 
 People affected by the Eaton and Palisades fires will prioritize issues that are most important to them. This shapes the community deliberations.
 
-### Review 
+### ⚪️ Review 
 
 You will take a break while we review the agenda-setting conversations. We will examine the items that surfaced from community input, analyze data, and gather insights. All of this information will help plan the deliberation phase.
 
-### Planning
+### ⚪️ Planning
 
 The Engaged California team will carefully set the stage for effective deliberation. We’ll work with our partners to set up deliberations that lead to actionable and relevant next steps.
 
@@ -49,11 +49,11 @@ We’ll use the takeaways from agenda setting to find the right policymakers and
 
 This might take a while. The work requires a lot of detail and care to ensure we enable deliberations that lead to actionable and relevant next steps.
 
-### Deliberation
+### ⚪️ Deliberation
 
 You will discuss what the community needs most. You’ll reach a consensus on how to ensure a speedy and equitable recovery. We don’t expect this to be easy. Some topics might be triggering. But reaching consensus lets you inform what actions state or local officials take on fire recovery.
 
-### Reporting
+### ⚪️ Reporting
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 

--- a/site/zh-hant/lafires-recovery.md
+++ b/site/zh-hant/lafires-recovery.md
@@ -57,14 +57,14 @@ You will discuss what the community needs most. You’ll reach a consensus on ho
 
 We will review and analyze the outcomes of the deliberation phase. We’ll work with government officials to find actions that respond to the deliberation. We will post a report of findings and actions on this website.
 
-## General information
+### General information
 
 * Participation is voluntary
 * You will not be paid for your time
 * You must be 18 years or older to participate
 * We will protect and keep personal information private 
 
-## Code of conduct
+### Code of conduct
 
 * Everyone involved in the Engaged California process must follow a pledge of civility
 * You should be open to listening and sharing 

--- a/site/zh-hant/lafires-recovery.md
+++ b/site/zh-hant/lafires-recovery.md
@@ -1,7 +1,7 @@
 ---
 title: Los Angeles fires recovery
 description: Engaged California is an online platform that makes it easier for Californians to have a voice in government. Engaged California's first topic is recovery from the Los Angeles wildfires.
-layout: page
+layout: page-with-form
 keywords:
   - Los Angeles
   - fires
@@ -15,7 +15,7 @@ tags:
 
 The State of California is bringing survivors and those impacted by the Los Angeles wildfires together to engage, interact, and share ideas. These insights will help shape recovery plans and collectively design wildfire recovery policy. Engaged California expands California’s all-in response to the wildfires. This platform allows state and local officials to hear and understand the needs of the people who survived the devastating fires.
 
-[Sign up to stay informed](/#sign-up)
+[Sign up to stay informed](#sign-up)
 
 ## Overview
 


### PR DESCRIPTION
Includes an un-styled, text-only version of the new Los Angeles Fires Recovery page. English only.