### PR TITLE
Updates to stylesheet used for Ethelo

### DIFF
--- a/scripts/ethelo-css/government-efficiencies/government-efficiencies-development.css
+++ b/scripts/ethelo-css/government-efficiencies/government-efficiencies-development.css
@@ -1,0 +1,1137 @@
+/* Instance specific CSS */
+.panel-body.signin-form::before,
+.invited-panel .panel-body::before {
+  content: "You have been invited to CA Government efficiencies." !important;
+}
+
+/* Demo mode UX improvements */
+.new-comment .form-comment-container-outer {
+  /* display: none !important; */
+}
+
+/* New styles to organize into rest of stylesheet */
+.nav-item-container.list-group-item ul.list-group .nav-item-container a {
+  /* padding-left: 40px !important; */
+}
+
+.prompt {
+  font-size: 2rem;
+}
+
+.prompt-box {
+  background-color: #f0e6dc;
+  margin: 20px 0px;
+  padding: 40px;
+  border-radius: 20px;
+}
+
+span.bigger-emoji {
+  font-size: 4.4rem;
+}
+
+/* remove client feedback button */
+a.client-feedback {
+  display: none;
+}
+
+.top-navigation-btn {
+  display: none;
+}
+
+.navbar-brand img.custom-logo.visible-xs-inline {
+  max-height: 50px;
+}
+
+.visible-xs.visible-sm.navbar-brand.decision-title {
+  margin-top: 10px;
+}
+
+.comment-section-btns.btn-xs {
+  margin-left: 32px;
+}
+
+.form-group .help-block {
+  position: relative;
+}
+
+/*--- Sign in form ----*/
+
+.signin-form strong {
+  display: none;
+}
+
+.signin-form p {
+  font-weight: 700;
+  font-size: 2.2rem !important;
+}
+
+#auth-modal-label {
+  display: none;
+}
+
+/* Comment title styling  */
+
+.instruct p {
+  font-weight: 700;
+  font-size: 2rem !important;
+}
+
+/*---- Account ----*/
+#edit-profile .form-group:has([name="username"]) {
+  display: none;
+}
+
+#edit-profile .form-group:has([name="username"]) input {
+  opacity: 0.3;
+}
+
+/* -- User profile menu ----*/
+li.navbar-user-dropdown {
+  display: none !important;
+}
+
+/*---- Invited panel ----*/
+.invited-panel .panel-body p {
+  display: none;
+}
+
+.panel-body.signin-form::before,
+.invited-panel .panel-body::before {
+  font-weight: 700;
+  font-size: 2.2rem !important;
+  padding-bottom: 60px;
+}
+.panel-body.signin-form p:first-child,
+.invited-panel .panel-footer {
+  display: none;
+}
+
+/*---- Typography ----*/
+
+/*---- Spacing and Layout ----*/
+p + p,
+.comment-item-container + .comment-item-container,
+.ethelo-likert-group,
+.form-group.row {
+  margin-top: 1.5em;
+}
+
+.comment-replies {
+  padding-left: 20px;
+}
+
+.hide-comments {
+  right: 0;
+}
+
+.page-voting-option-category .likert-container {
+  padding: 16px 40px;
+}
+
+.page-voting-option-category .likert-container .ember-view {
+  padding-bottom: 0px;
+}
+
+.comment-item-container .row-content .list-group-item-text {
+  margin-top: 0.25em;
+  margin-bottom: 0;
+}
+
+.form-group .pull-right {
+  float: none !important;
+}
+
+hr.fancy {
+  border: 0;
+  margin: 40px 0 0 0 !important;
+  height: 1px;
+  background-image: linear-gradient(
+    to right,
+    rgba(0, 0, 0, 0.25),
+    rgba(0, 0, 0, 0.25),
+    rgba(0, 0, 0, 0.25)
+  );
+}
+
+/*---- Other ----*/
+li.navbar-user-dropdown {
+  display: block;
+}
+
+li.navbar-user-dropdown span[aria-label="User Menu"] {
+  color: #1c2745;
+}
+
+li.navbar-user-dropdown span[aria-label="User Menu"]:hover {
+  color: #1c2745;
+}
+
+/* Hide User name and sign up boxes in login */
+label[for="auth_name"] {
+  display: none;
+}
+input#auth_name {
+  display: none;
+}
+
+.sign-checkbox .info label {
+  display: none;
+  padding-bottom: 100px;
+}
+
+#signup-page-text p img {
+  content: url("https://engaged.ca.gov/public/images/header-logo.svg");
+}
+
+.untabbed-modal-panel .checkbox.bottom-0 label {
+  display: none;
+}
+
+.list-group-item.comment-item-container .comment-item .user-name {
+  display: none;
+}
+
+.signon {
+  margin: 40px;
+}
+
+.untabbed-modal-panel .panel-body p {
+  margin-top: 16px;
+  font-size: 120%;
+  font-weight: 700;
+  line-height: 1.275;
+}
+
+.untabbed-modal-panel .panel-body label.info {
+  font-size: 120%;
+  line-height: 1.275;
+}
+
+.untabbed-modal-panel .panel-footer {
+  font-size: 120%;
+  line-height: 1.275;
+}
+
+.untabbed-modal-panel .panel-body label.info a {
+  font-size: inherit;
+  line-height: 1.275;
+  color: #5489a3;
+  text-decoration: underline;
+}
+
+strong#auth-modal-label {
+  font-size: 170%;
+  letter-spacing: -0.015em;
+  font-family: "Noto Sans", sans-serif;
+  font-weight: 900;
+  line-height: 120%;
+}
+
+.form-group.has-error .help-block,
+.form-group.has-error label.control-label {
+  color: #ffcda4;
+  position: relative;
+  margin-top: 16px;
+}
+
+/* Match fonts colors default to engaged.ca.gov */
+body
+  *:not(
+    .h4.panel-slider__title > .float-left,
+    .material-icons-outlined,
+    .material-icons,
+    .person,
+    .icon
+  ) {
+  font-family: "Noto Sans", system-ui, sans-serif !important;
+}
+
+h1,
+h2,
+h3,
+.h4.panel-slider__title > .float-left,
+.display-text {
+  letter-spacing: -0.015em;
+  font-family: "Noto Sans", sans-serif;
+  font-weight: 900;
+  line-height: 150%;
+}
+.navbar .navbar-brand {
+  color: #1c2745;
+  height: 80px;
+  line-height: 47px;
+}
+
+.nav-item.active {
+  background-color: #FFCDA4;
+}
+
+.list-group-item .material-icons-outlined.half-complete {
+  color: #6c757d;
+}
+.panel-slider__title {
+  font-size: 2.4rem;
+}
+
+#page-header {
+  width: 100%;
+  text-align: left;
+  margin: 0;
+  vertical-align: middle;
+  padding-bottom: 0px;
+}
+
+b,
+strong {
+  font-weight: 700;
+}
+
+body {
+  background-color: #f3f3f3;
+}
+
+/* Change navbar background */
+.navbar.primary-accent-bg,
+.navbar.navbar-default.primary-accent-bg {
+  background-color: #ffffff;
+}
+
+/* Change navbar title color */
+.navbar .navbar-nav > li.decision-title,
+.navbar .navbar-nav > li > a {
+  color: #000;
+  font-family: "Noto Sans";
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 150%; /* 36px */
+  letter-spacing: -0.264px;
+}
+
+/* Match navbar background color for user dropdown */
+.navbar-user-dropdown {
+  background-color: #ffffff;
+}
+
+/* Adjust required style */
+.required {
+  font-style: normal;
+  text-decoration: none;
+  color: #fd7e14;
+  float: left !important;
+  margin-right: 8px;
+  margin-top: 0.9rem;
+  display: inline-block;
+}
+
+.control-label .required {
+  margin-top: 0rem;
+}
+
+.required + h2 {
+  display: flex;
+  float: none !important;
+  margin-bottom: 16px;
+}
+
+/* Fix responsive navbar */
+
+.navbar .navbar-brand,
+.custom-logo {
+  height: auto;
+  padding: 0 15px 10px 15px;
+  line-height: 2.5em;
+}
+
+.h1,
+h1 {
+  font-size: 3.2rem;
+}
+
+.h2,
+h2 {
+  font-size: 2.3rem;
+}
+
+.h1,
+.h2,
+.h3,
+h1,
+h2,
+h3 {
+  margin-top: 0.9rem;
+  margin-bottom: 0.9rem;
+}
+
+.navbar .navbar-brand,
+.custom-logo {
+  padding: 0px;
+}
+
+.navbar-brand {
+  color: #000;
+  font-family: "Noto Sans";
+  /* font-size: 1.2rem; */
+  font-style: normal;
+  font-weight: 500;
+  line-height: 126%; /* 22.68px */
+  letter-spacing: -0.198px;
+  display: block;
+}
+.navbar .navbar-nav > li.decision-title,
+.navbar-brand.decision-title {
+  margin-right: 40px;
+  white-space: initial;
+  overflow: visible;
+  text-overflow: initial;
+  line-height: 1.25rem;
+  margin-top: 20px;
+  margin-left: 15px;
+  padding: 10px;
+}
+
+@media only screen and (max-width: 992px) {
+  .navbar-brand {
+    font-size: 1.4rem;
+  }
+
+  .navbar-brand {
+    font-size: 1.4rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 126%; /* 22.68px */
+    letter-spacing: -0.198px;
+    display: block;
+  }
+  .navbar .navbar-nav > li.decision-title,
+  .navbar-brand.decision-title {
+    margin-right: 40px;
+    white-space: initial;
+    overflow: auto;
+    text-overflow: initial;
+    line-height: 1.25rem;
+    margin-top: 20px;
+    padding: 10px;
+  }
+}
+
+/* Form overrides */
+.qcheckbox p {
+  font-size: 23px;
+  /* font-weight: 700; */
+  line-height: 1.275;
+}
+
+/* Slider style overrides */
+.qlabeled_slider .control-label p {
+  font-size: 23px;
+  font-weight: 700;
+  line-height: 1.275;
+}
+
+.qlabeled_slider .control-label .required {
+  line-height: 1.275;
+  margin-bottom: 16px;
+}
+
+.form-control.survey-labeled-slider {
+  margin-top: 32px;
+}
+
+.qlabeled_slider.row {
+  margin-bottom: 48px;
+}
+
+.labeled-slider .slider .tooltip-inner::before,
+.range-slider .slider .tooltip-inner::before,
+.survey-slider .slider .tooltip-inner::before,
+.weighting-slider .slider .tooltip-inner::before {
+  content: "Use slider to vote";
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  color: #1c2745;
+  background: #fcb880;
+  border: none;
+  border-radius: 4px;
+  white-space: nowrap;
+  max-width: none;
+  text-align: center;
+  line-height: 19px;
+  left: 0;
+  top: 0;
+  padding: 0 5px;
+}
+
+/* Make it easier to see the modal close button */
+button.close i.material-icons {
+  color: #1c2745;
+}
+
+button.close {
+  opacity: 1;
+}
+
+/*-- Buttons --*/
+.btn.btn-raised.btn-primary,
+.btn.btn-raised.btn-danger,
+.btn.navigation-button,
+.btn.ethelo-likert-group-mobile {
+  background-color: #e79450 !important;
+  color: #1c2745;
+  text-transform: lowercase;
+  font-size: 1.65rem;
+  border-radius: 0.625rem;
+  padding: 0.5em 2.5em;
+  letter-spacing: -0.015em;
+  font-family: "Noto Sans", sans-serif;
+  font-weight: 400;
+  border: 2px solid transparent;
+  transition: none;
+}
+
+.btn.btn-raised.btn-danger {
+  background-color: #fff !important;
+  color: #1c2745;
+  border: 2px solid #d24532;
+}
+
+.btn.btn-raised.btn-primary:hover,
+.btn.btn-raised.btn-primary:active {
+  background-color: #e79450;
+}
+
+.btn.btn-raised.btn-danger::first-letter,
+.btn.btn-raised.btn-primary::first-letter,
+.btn.navigation-button::first-letter,
+.btn.ethelo-likert-group-mobile::first-letter {
+  text-transform: uppercase !important;
+}
+
+.bottom-nav-buttons > .row .btn.navigation-button:not([aria-disabled="true"]),
+.btn.ethelo-likert-group-mobile {
+  border-radius: 0.625rem;
+  border: 2px solid #e79450;
+}
+
+.bottom-nav-buttons > .row > div:first-child .btn.navigation-button {
+  background: #fff !important;
+  color: #000;
+}
+
+.bottom-nav-buttons .btn.navigation-button:focus,
+.btn.ethelo-likert-group-mobile:focus {
+  border: 2px solid #e79450 !important;
+  outline: 1px solid #000 !important;
+}
+
+.bottom-nav-buttons > .row .btn.navigation-button[aria-label="NEXT"] {
+  background-color: #e79450;
+  color: #1c2745;
+  font-weight: 700;
+}
+
+.btn.navigation-button[aria-disabled="true"] {
+  border: 2px solid #ddd;
+  background-color: #f2f2f2 !important;
+  color: rgba(148, 152, 155, 0.85) !important;
+}
+
+button.btn:focus,
+button.btn.btn-raised.navigation-button.btn-primary:focus {
+  border: inherit !important;
+}
+
+.bottom-nav-buttons > .row .navigation-button:hover {
+  background-color: inherit;
+}
+
+.container-fluid.bottom-nav-buttons {
+  display: flex;
+  flex-direction: row;
+  padding-left: 0;
+}
+
+/* Remove all padding */
+.container-fluid.bottom-nav-buttons div[class*=" col-"] {
+  margin: 0;
+  padding: 0;
+}
+
+.container-fluid.bottom-nav-buttons
+  div[class*=" col-"]
+  .ember-view
+  .navigation-button {
+  margin: 0 16px 0 0px;
+  padding: 8px 32px;
+}
+
+@media only screen and (max-width: 768px) {
+  .container-fluid.bottom-nav-buttons
+    div[class*=" col-"]
+    .ember-view
+    .navigation-button:not([aria-label="BACK"]) {
+    margin: 0 0px 0 16px;
+    padding: 8px 32px;
+  }
+  .container-fluid.bottom-nav-buttons
+    div[class*=" col-"]
+    .ember-view
+    .navigation-button[aria-label="NEXT"] {
+    margin: 0 0px 0 16px;
+    padding: 8px 32px;
+  }
+}
+
+/*---- Collapse / Toggle styles ----*/
+
+.panel.panel-default > .panel-heading,
+.panel > .panel-heading {
+  background-color: transparent;
+  border-bottom: 1px solid #666666;
+  margin-bottom: 16px;
+}
+
+.expansion-toggle.primary-accent-bg {
+  background-color: #5489a3;
+  color: #fff !important;
+  font-size: 2rem;
+  font-weight: bold;
+}
+
+.expansion-toggle:focus {
+  outline: 2px solid currentColor;
+  outline-offset: -0.25em;
+}
+
+.container-fluid.bottom-nav-buttons {
+  display: flex;
+  flex-direction: row;
+  padding-left: 0;
+}
+
+/* Fix page padding */
+.main {
+  padding: 8px;
+}
+
+a {
+  color: #1c2745;
+}
+
+.prompt-box a,
+.panel.body a {
+  color: #1c2745;
+  font-style: normal;
+  font-weight: 700;
+}
+
+/* Favorite icon */
+i.material-icons.favorite {
+  color: #ffcda4;
+}
+
+/* Remove box shadows */
+.survey-page textarea.ember-text-area.form-control {
+  box-shadow: none;
+  background-color: #fff;
+}
+
+/* Improve appearance of drop shadows */
+.btn.btn-raised:not(.btn-link) {
+  box-shadow: none;
+}
+
+.dropdown .comment-privacy-select .open {
+  box-shadow: none;
+}
+/*---- Panels ----*/
+
+div[class*="-column"] .panel {
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.12), 0 1px 2px 0 rgba(0, 0, 0, 0.12);
+}
+
+[role="main"] .panel {
+  background: transparent;
+  box-shadow: none;
+}
+
+/*---- Input text and textarea ----*/
+
+.form-control,
+.form-group .form-control {
+  border: 2px solid #d1d1d1;
+  border-radius: 0.25em;
+  background-image: none;
+  padding: 0.5em;
+  height: auto;
+  background-color: #fff;
+}
+
+/* fix radio button / checkbox hover effect on textboxes and textareas */
+.form-group.qradio.is-focused input[type="text"],
+.form-group.qradio.is-focused textarea,
+.form-group.qcheckbox.is-focused input[type="text"],
+.form-group.qcheckbox.is-focused textarea {
+  background-image: none;
+}
+
+.radio span,
+label.radio-inline span {
+  top: 6px !important;
+}
+
+.page-survey-page .panel-body + div.form-group {
+  padding: 2em;
+  background-color: #ffffff;
+}
+
+div:has(> .form-group) + div {
+  margin-top: 1em;
+}
+
+.form-group p {
+  margin-bottom: 0.25em !important;
+}
+
+.form-comment .form-group {
+  margin-top: 0.25em;
+}
+
+/* Progress bar */
+.progress-bar-voting {
+  padding-right: 2px;
+}
+
+.progress-bar-voting .progress-bar-voting__circle {
+  border: 3px solid #1c2745;
+  width: 69px;
+  height: 69px;
+  font-size: 22px;
+  line-height: 60px;
+  margin-top: -26px;
+  margin-left: 2px;
+  background-color: #1c2745;
+  color: #fff;
+  padding-left: 4px;
+}
+
+.progress-bar-voting .progress-bar-voting__circle {
+  right: -2px;
+}
+
+.progress-bar-voting__circle {
+  margin-left: 4px;
+}
+
+.progress-bar-voting {
+  background-color: #e79450;
+}
+
+.progress-bar-voting .progress-bar-voting__fill {
+  background-color: #1c2745;
+  border-radius: 0px;
+}
+
+.progress-bar-voting span {
+  font-weight: 700;
+  letter-spacing: -0.266px;
+}
+
+section p,
+section li {
+  line-height: 1.7rem;
+}
+
+/*---- Likert overrides ----*/
+.panel:has(.likert-container) {
+  background: #fff;
+}
+
+.likert-container .ethelo-likert-group {
+  align-items: flex-start;
+}
+
+.ethelo-likert-group li.ethelo-likert-button-container .ethelo-likert-subtext,
+.ethelo-voted-label li.ethelo-likert-button-container .ethelo-likert-subtext {
+  display: block;
+  font-size: 1.2rem !important;
+  line-height: 1.5 !important;
+  margin-top: 0.75em;
+  text-transform: none !important;
+  visibility: visible;
+  font-weight: 400;
+}
+
+.ember-view.ethelo-likert-button-container {
+  flex-direction: column-reverse;
+}
+
+.ethelo-likert-subtext {
+  font-weight: bold;
+  text-transform: unset;
+}
+
+.ember-view.ethelo-likert-button-container > a[role="button"] {
+  background: #f6f6f6 !important;
+  border: 2px solid #d1d1d1;
+  border-radius: 50%;
+  display: flex;
+  height: 2em;
+  padding: 1em;
+  width: 2em;
+}
+
+.ember-view.ethelo-likert-button-container.active > .ethelo-likert-subtext {
+  font-weight: bold;
+}
+.ember-view.ethelo-likert-button-container.active > a[role="button"] {
+  border-color: #1c2745;
+  box-shadow: none;
+  padding: 1em;
+}
+
+.ember-view.ethelo-likert-button-container > a[role="button"] [aria-hidden] {
+  display: none;
+}
+
+.ember-view.ethelo-likert-button-container.active
+  > a[role="button"]
+  .ethelo-likert-indicator.hidden-xs.hidden-sm {
+  align-self: center;
+  background: #1c2745;
+  border-radius: 50%;
+  display: block !important;
+  height: unset;
+  margin: 0;
+  order: -1;
+  padding: 0.75em;
+  transform: translate(-0.75em);
+  width: unset;
+}
+
+div:not(.modal-body) .ethelo-likert-label.visible-md.visible-lg {
+  display: none !important;
+}
+.modal-body .ethelo-likert-text {
+  font-weight: normal;
+}
+
+.modal-body
+  .ember-view.ethelo-likert-button-container
+  > a[role="button"]
+  .ethelo-likert-text {
+  align-self: center;
+  color: #000 !important;
+  transform: translateX(2em);
+}
+.modal-body
+  .ember-view.ethelo-likert-button-container.active
+  > a[role="button"]
+  .ethelo-likert-text.visible-xs.visible-sm {
+  font-weight: bold;
+  transform: translateX(0.5em);
+}
+
+/* Remove uppercase text transformations */
+.btn,
+.btn-outline,
+.input-group-btn .btn {
+  text-transform: none;
+}
+
+.list-group-item.comment-item-container .comment-item .user-name {
+  text-transform: none;
+}
+
+/* Fix font colors on results page*/
+.card.result-card .detail-toggle .title {
+  color: #1c2745;
+}
+
+.card.flat .card-body .nav-pills > li > a {
+  color: #1c2745;
+}
+
+.panel-body {
+  padding: 0px;
+}
+
+#questions-panel .panel-body div.ember-view .panel-body:not(.panel-body) {
+  margin-bottom: 60px;
+}
+
+#questions-panel .panel-body div.ember-view .panel-body,
+#questions-panel .panel-body div.ember-view .panel-body + .qcheckbox {
+  margin-bottom: 0px;
+}
+
+.content-col .panel-body {
+  padding: 0px 16px 16px 16px;
+}
+
+.content-col .panel-body li:not(.comments),
+.content-col .panel-body p,
+.content-col .panel-body .option-description {
+  line-height: 170% !important;
+  font-size: 2rem;
+}
+.content-col .panel-body p {
+  margin-bottom: calc(0.7rem + 0.1vw);
+}
+.list-group .list-group-item {
+  padding-left: 0px;
+}
+
+.content-col .panel-body .form-group .control-label p {
+  font-weight: 700;
+  font-size: 2.2rem !important;
+}
+
+.nav-item-container a {
+  padding: 16px;
+}
+.list-group-item .material-icons-outlined {
+  top: 16px;
+  right: 8px;
+}
+.option-description .option-text p {
+  font-weight: 700;
+  margin-bottom: 1em;
+}
+
+/* Override comment styles */
+textarea.ember-text-area.form-control,
+.survey-page textarea.ember-text-area.form-control,
+.qtextarea {
+  margin: 0;
+  padding: 0;
+  box-shadow: none;
+  padding: 1.5em;
+  /* background-color: #fff; */
+  height: auto;
+  min-height: 150px;
+}
+
+.survey-page .form-group {
+  /* padding: 16px 40px; */
+}
+
+.list-group .row-picture img.circle {
+  display: none;
+}
+.comment-item small {
+  font-size: 1.5rem;
+  display: inline-block;
+  margin-right: 0.25em;
+}
+
+.dropdown .comment-privacy-select .open {
+  box-shadow: none;
+}
+.dropdown .comment-privacy-select {
+  line-height: 100%;
+}
+
+.list-group-item.new-comment-container .btn {
+  margin: 10px 24px;
+}
+
+.comments > .comment-item-container > .comment-item {
+  padding-right: 2em;
+}
+
+@media only screen and (max-width: 768px) {
+  .comments > .comment-item-container > .comment-item {
+    padding-right: 16px;
+  }
+  .list-group .list-group-item .row-content {
+    display: inline-block;
+    width: calc(100% - 16px);
+    min-height: 66px;
+  }
+}
+
+.comment-item,
+.comment-item,
+.new-comment-container .form-group {
+  display: flex;
+  align-items: flex-start;
+}
+
+.comment-item:before,
+    /* .new-comment-container .form-group:before,  */
+    .page-survey-page .form-comment-container-outer:before,
+    .page-voting-option-category .form-comment-container-outer:before {
+  content: "";
+  display: inline-block;
+  background-position: center center !important;
+  background-repeat: no-repeat !important;
+  background-size: 65% !important;
+  border-radius: 50%;
+  padding: 2.25rem !important;
+  margin-right: 1rem;
+  background-image: url("https://odi-uploads.s3.us-west-2.amazonaws.com/store/cc73297c0ea1ec5a2622a5e54976f2e1.png");
+}
+
+.likert-container strong.pull-right {
+  text-transform: initial;
+}
+
+button.comment-section-btns,
+.form-comment-container-outer .btn.btn-raised,
+.form-comment-container-outer .btn.btn-raised.btn-default {
+  background-color: #e79450 !important;
+}
+
+.right-sidebar__bottom.panel-group .panel-body {
+  padding: 8px;
+}
+
+.hub-container .panel-body {
+  padding: 16px;
+  background-color: #f0e6dc;
+  margin: 20px 0px;
+  padding: 40px;
+  border-radius: 20px;
+}
+
+.comment-item-container:nth-child(3n + 1) .comment-item:before,
+.comment-replies
+  .comment-item-container:nth-child(3n + 1)
+  .comment-item:before {
+  background-color: #ffcda4;
+}
+
+.comment-item-container:nth-child(3n + 2) .comment-item:before,
+.comment-replies
+  .comment-item-container:nth-child(3n + 2)
+  .comment-item:before {
+  background-color: #fff4eb;
+}
+
+.comment-item-container:nth-child(3n + 3) .comment-item:before {
+  background-color: #91bdd3;
+}
+
+.list-group-item.comment-item-container
+  .comment-item:hover
+  > .row-content
+  .more-actions {
+  right: 1em;
+}
+
+.list-group.comments {
+  margin-bottom: 60px;
+}
+
+.btn.btn-xs {
+  font-size: 16px;
+}
+
+.help-block,
+.form-group .help-block,
+.form-group + .help-block {
+  padding: 16px;
+  background-color: #f0e6dc;
+  margin: 10px 24px;
+  padding: 10px 32px;
+  border-radius: 20px;
+}
+
+/*---- Radio and Checkbox ----*/
+.form-group .checkbox label,
+.form-group .radio label,
+.form-group label {
+  font-size: 2rem;
+}
+
+.checkbox,
+.radio {
+  margin-top: 0px;
+}
+
+.checkbox .checkbox-material,
+label.checkbox-inline .checkbox-material {
+  padding-right: 16px;
+}
+
+.radio + .radio,
+.checkbox > br + label {
+  margin-top: 0.5em;
+}
+
+.checkbox-group,
+.radio-group {
+  margin-bottom: 1em;
+}
+
+.form-group .dropdown:not(.comment-privacy-select, .more-actions) {
+  width: 100%;
+  min-width: 15ch;
+  max-width: 30ch;
+  border: 2px solid #d1d1d1;
+  border-radius: 0.25em;
+  font-size: 1.5rem;
+  cursor: pointer;
+  background-color: #fff;
+  align-items: center;
+  padding: 0.75em;
+  display: flex;
+  margin-bottom: 16px;
+}
+
+.form-group .dropdown:not(.comment-privacy-select, .more-actions) .x-select {
+  outline: none;
+
+  background: transparent;
+  border: none;
+  padding: 0 1em 0 0;
+  margin: 0;
+  width: 100%;
+  font-family: inherit;
+  font-size: inherit;
+  cursor: inherit;
+  line-height: inherit;
+  transform: scaleX(108%) translateX(0.4em);
+}
+
+.x-select::-ms-expand {
+  display: none;
+}
+
+.form-group .dropdown::after {
+  content: "";
+  width: 0.8em;
+  height: 0.5em;
+  background-color: #548097;
+  clip-path: polygon(100% 0%, 0 0%, 50% 100%);
+  justify-self: end;
+}
+
+/* Commenting ----*/
+.comment-privacy-select {
+  display: none !important;
+}
+.comment-like-count {
+  vertical-align: baseline;
+}
+.flag-count {
+  display: none;
+}
+
+/*-- fix next button bug (test) --*/
+.container-fluid.bottom-nav-buttons * {
+  float: none !important;
+  width: auto !important;
+}
+
+.container-fluid.bottom-nav-buttons .btn {
+  max-width: 9em; /* Don't let next button get too wide */
+}
+
+.container-fluid.bottom-nav-buttons .row.inner {
+  display: flex;
+  flex-direction: row;
+}

--- a/scripts/ethelo-css/los-angeles-fires-recovery/tell-us-your-recovery-priorities-demo-mode.css
+++ b/scripts/ethelo-css/los-angeles-fires-recovery/tell-us-your-recovery-priorities-demo-mode.css
@@ -1,0 +1,1138 @@
+/* Instance specific CSS */
+.panel-body.signin-form::before,
+.invited-panel .panel-body::before {
+  content: "You have been invited to tell us your Los Angeles fires recovery priorities." !important;
+}
+
+/* Demo mode UX improvements */
+.new-comment .form-comment-container-outer {
+  display: none !important;
+}
+
+/* New styles to organize into rest of stylesheet */
+.nav-item-container.list-group-item ul.list-group .nav-item-container a {
+  padding-left: 40px !important;
+}
+
+.prompt {
+  font-size: 2rem;
+}
+
+.prompt-box {
+  background-color: #f0e6dc;
+  margin: 20px 0px;
+  padding: 40px;
+  border-radius: 20px;
+}
+
+span.bigger-emoji {
+  font-size: 4.4rem;
+}
+
+/* remove client feedback button */
+a.client-feedback {
+  display: none;
+}
+
+.top-navigation-btn {
+  display: none;
+}
+
+.navbar-brand img.custom-logo.visible-xs-inline {
+  max-height: 50px;
+}
+
+.visible-xs.visible-sm.navbar-brand.decision-title {
+  margin-top: 10px;
+}
+
+.comment-section-btns.btn-xs {
+  margin-left: 32px;
+}
+
+.form-group .help-block {
+  position: relative;
+}
+
+/*--- Sign in form ----*/
+
+.signin-form strong {
+  display: none;
+}
+
+.signin-form p {
+  font-weight: 700;
+  font-size: 2.2rem !important;
+}
+
+#auth-modal-label {
+  display: none;
+}
+
+/* Comment title styling  */
+
+.instruct p {
+  font-weight: 700;
+  font-size: 2rem !important;
+}
+
+/*---- Account ----*/
+#edit-profile .form-group:has([name="username"]) {
+  display: none;
+}
+
+#edit-profile .form-group:has([name="username"]) input {
+  opacity: 0.3;
+}
+
+/* -- User profile menu ----*/
+li.navbar-user-dropdown {
+  display: none !important;
+}
+
+/*---- Invited panel ----*/
+.invited-panel .panel-body p {
+  display: none;
+}
+
+.panel-body.signin-form::before,
+.invited-panel .panel-body::before {
+  font-weight: 700;
+  font-size: 2.2rem !important;
+  padding-bottom: 60px;
+}
+.panel-body.signin-form p:first-child,
+.invited-panel .panel-footer {
+  display: none;
+}
+
+/*---- Typography ----*/
+
+/*---- Spacing and Layout ----*/
+p + p,
+.comment-item-container + .comment-item-container,
+.ethelo-likert-group,
+.form-group.row {
+  margin-top: 1.5em;
+}
+
+.comment-replies {
+  padding-left: 20px;
+}
+
+.hide-comments {
+  right: 0;
+}
+
+.page-voting-option-category .likert-container {
+  padding: 16px 40px;
+}
+
+.page-voting-option-category .likert-container .ember-view {
+  padding-bottom: 0px;
+}
+
+.comment-item-container .row-content .list-group-item-text {
+  margin-top: 0.25em;
+  margin-bottom: 0;
+}
+
+.form-group .pull-right {
+  float: none !important;
+}
+
+hr.fancy {
+  border: 0;
+  margin: 40px 0 0 0 !important;
+  height: 1px;
+  background-image: linear-gradient(
+    to right,
+    rgba(0, 0, 0, 0.25),
+    rgba(0, 0, 0, 0.25),
+    rgba(0, 0, 0, 0.25)
+  );
+}
+
+/*---- Other ----*/
+li.navbar-user-dropdown {
+  display: block;
+}
+
+li.navbar-user-dropdown span[aria-label="User Menu"] {
+  color: #1c2745;
+}
+
+li.navbar-user-dropdown span[aria-label="User Menu"]:hover {
+  color: #1c2745;
+}
+
+/* Hide User name and sign up boxes in login */
+label[for="auth_name"] {
+  display: none;
+}
+input#auth_name {
+  display: none;
+}
+
+.sign-checkbox .info label {
+  display: none;
+  padding-bottom: 100px;
+}
+
+#signup-page-text p img {
+  content: url("https://engaged.ca.gov/public/images/header-logo.svg");
+}
+
+.untabbed-modal-panel .checkbox.bottom-0 label {
+  display: none;
+}
+
+.list-group-item.comment-item-container .comment-item .user-name {
+  display: none;
+}
+
+.signon {
+  margin: 40px;
+}
+
+.untabbed-modal-panel .panel-body p {
+  margin-top: 16px;
+  font-size: 120%;
+  font-weight: 700;
+  line-height: 1.275;
+}
+
+.untabbed-modal-panel .panel-body label.info {
+  font-size: 120%;
+  line-height: 1.275;
+}
+
+.untabbed-modal-panel .panel-footer {
+  font-size: 120%;
+  line-height: 1.275;
+}
+
+.untabbed-modal-panel .panel-body label.info a {
+  font-size: inherit;
+  line-height: 1.275;
+  color: #5489a3;
+  text-decoration: underline;
+}
+
+strong#auth-modal-label {
+  font-size: 170%;
+  letter-spacing: -0.015em;
+  font-family: "Noto Sans", sans-serif;
+  font-weight: 900;
+  line-height: 120%;
+}
+
+.form-group.has-error .help-block,
+.form-group.has-error label.control-label {
+  color: #ffcda4;
+  position: relative;
+  margin-top: 16px;
+}
+
+/* Match fonts colors default to engaged.ca.gov */
+body
+  *:not(
+    .h4.panel-slider__title > .float-left,
+    .material-icons-outlined,
+    .material-icons,
+    .person,
+    .icon
+  ) {
+  font-family: "Noto Sans", system-ui, sans-serif !important;
+}
+
+h1,
+h2,
+h3,
+.h4.panel-slider__title > .float-left,
+.display-text {
+  letter-spacing: -0.015em;
+  font-family: "Noto Sans", sans-serif;
+  font-weight: 900;
+  line-height: 150%;
+}
+.navbar .navbar-brand {
+  color: #1c2745;
+  height: 80px;
+  line-height: 47px;
+}
+
+.nav-item.active {
+  background-color: #FFCDA4;
+}
+
+.list-group-item .material-icons-outlined.half-complete {
+  color: #6c757d;
+}
+.panel-slider__title {
+  font-size: 2.4rem;
+}
+
+#page-header {
+  width: 100%;
+  text-align: left;
+  margin: 0;
+  vertical-align: middle;
+  padding-bottom: 0px;
+}
+
+b,
+strong {
+  font-weight: 700;
+}
+
+body {
+  background-color: #f3f3f3;
+}
+
+/* Change navbar background */
+.navbar.primary-accent-bg,
+.navbar.navbar-default.primary-accent-bg {
+  background-color: #ffffff;
+}
+
+/* Change navbar title color */
+.navbar .navbar-nav > li.decision-title,
+.navbar .navbar-nav > li > a {
+  color: #000;
+  font-family: "Noto Sans";
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 150%; /* 36px */
+  letter-spacing: -0.264px;
+}
+
+/* Match navbar background color for user dropdown */
+.navbar-user-dropdown {
+  background-color: #ffffff;
+}
+
+/* Adjust required style */
+.required {
+  font-style: normal;
+  text-decoration: none;
+  color: #fd7e14;
+  float: left !important;
+  margin-right: 8px;
+  margin-top: 0.9rem;
+  display: inline-block;
+}
+
+.control-label .required {
+  margin-top: 0rem;
+}
+
+.required + h2 {
+  display: flex;
+  float: none !important;
+  margin-bottom: 16px;
+}
+
+/* Fix responsive navbar */
+
+.navbar .navbar-brand,
+.custom-logo {
+  height: auto;
+  padding: 0 15px 10px 15px;
+  line-height: 2.5em;
+}
+
+.h1,
+h1 {
+  font-size: 3.2rem;
+}
+
+.h2,
+h2 {
+  font-size: 2.3rem;
+}
+
+.h1,
+.h2,
+.h3,
+h1,
+h2,
+h3 {
+  margin-top: 0.9rem;
+  margin-bottom: 0.9rem;
+}
+
+.navbar .navbar-brand,
+.custom-logo {
+  padding: 0px;
+}
+
+.navbar-brand {
+  color: #000;
+  font-family: "Noto Sans";
+  /* font-size: 1.2rem; */
+  font-style: normal;
+  font-weight: 500;
+  line-height: 126%; /* 22.68px */
+  letter-spacing: -0.198px;
+  display: block;
+}
+.navbar .navbar-nav > li.decision-title,
+.navbar-brand.decision-title {
+  margin-right: 40px;
+  white-space: initial;
+  overflow: visible;
+  text-overflow: initial;
+  line-height: 1.25rem;
+  margin-top: 20px;
+  margin-left: 15px;
+  padding: 10px;
+}
+
+@media only screen and (max-width: 992px) {
+  .navbar-brand {
+    font-size: 1.4rem;
+  }
+
+  .navbar-brand {
+    font-size: 1.4rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 126%; /* 22.68px */
+    letter-spacing: -0.198px;
+    display: block;
+  }
+  .navbar .navbar-nav > li.decision-title,
+  .navbar-brand.decision-title {
+    margin-right: 40px;
+    white-space: initial;
+    overflow: auto;
+    text-overflow: initial;
+    line-height: 1.25rem;
+    margin-top: 20px;
+    padding: 10px;
+  }
+}
+
+/* Form overrides */
+.qcheckbox p {
+  font-size: 23px;
+  /* font-weight: 700; */
+  line-height: 1.275;
+}
+
+/* Slider style overrides */
+.qlabeled_slider .control-label p {
+  font-size: 23px;
+  font-weight: 700;
+  line-height: 1.275;
+}
+
+.qlabeled_slider .control-label .required {
+  line-height: 1.275;
+  margin-bottom: 16px;
+}
+
+.form-control.survey-labeled-slider {
+  margin-top: 32px;
+}
+
+.qlabeled_slider.row {
+  margin-bottom: 48px;
+}
+
+.labeled-slider .slider .tooltip-inner::before,
+.range-slider .slider .tooltip-inner::before,
+.survey-slider .slider .tooltip-inner::before,
+.weighting-slider .slider .tooltip-inner::before {
+  content: "Use slider to vote";
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  color: #1c2745;
+  background: #fcb880;
+  border: none;
+  border-radius: 4px;
+  white-space: nowrap;
+  max-width: none;
+  text-align: center;
+  line-height: 19px;
+  left: 0;
+  top: 0;
+  padding: 0 5px;
+}
+
+/* Make it easier to see the modal close button */
+button.close i.material-icons {
+  color: #1c2745;
+}
+
+button.close {
+  opacity: 1;
+}
+
+/*-- Buttons --*/
+.btn.btn-raised.btn-primary,
+.btn.btn-raised.btn-danger,
+.btn.navigation-button,
+.btn.ethelo-likert-group-mobile {
+  background-color: #e79450 !important;
+  color: #1c2745;
+  text-transform: lowercase;
+  font-size: 1.65rem;
+  border-radius: 0.625rem;
+  padding: 0.5em 2.5em;
+  letter-spacing: -0.015em;
+  font-family: "Noto Sans", sans-serif;
+  font-weight: 400;
+  border: 2px solid transparent;
+  transition: none;
+}
+
+.btn.btn-raised.btn-danger {
+  background-color: #fff !important;
+  color: #1c2745;
+  border: 2px solid #d24532;
+}
+
+.btn.btn-raised.btn-primary:hover,
+.btn.btn-raised.btn-primary:active {
+  background-color: #e79450;
+}
+
+.btn.btn-raised.btn-danger::first-letter,
+.btn.btn-raised.btn-primary::first-letter,
+.btn.navigation-button::first-letter,
+.btn.ethelo-likert-group-mobile::first-letter {
+  text-transform: uppercase !important;
+}
+
+.bottom-nav-buttons > .row .btn.navigation-button:not([aria-disabled="true"]),
+.btn.ethelo-likert-group-mobile {
+  border-radius: 0.625rem;
+  border: 2px solid #e79450;
+}
+
+.bottom-nav-buttons > .row > div:first-child .btn.navigation-button {
+  background: #fff !important;
+  color: #000;
+}
+
+.bottom-nav-buttons .btn.navigation-button:focus,
+.btn.ethelo-likert-group-mobile:focus {
+  border: 2px solid #e79450 !important;
+  outline: 1px solid #000 !important;
+}
+
+.bottom-nav-buttons > .row .btn.navigation-button[aria-label="NEXT"] {
+  background-color: #e79450;
+  color: #1c2745;
+  font-weight: 700;
+}
+
+.btn.navigation-button[aria-disabled="true"] {
+  border: 2px solid #ddd;
+  background-color: #f2f2f2 !important;
+  color: rgba(148, 152, 155, 0.85) !important;
+}
+
+button.btn:focus,
+button.btn.btn-raised.navigation-button.btn-primary:focus {
+  border: inherit !important;
+}
+
+.bottom-nav-buttons > .row .navigation-button:hover {
+  background-color: inherit;
+}
+
+.container-fluid.bottom-nav-buttons {
+  display: flex;
+  flex-direction: row;
+  padding-left: 0;
+}
+
+/* Remove all padding */
+.container-fluid.bottom-nav-buttons div[class*=" col-"] {
+  margin: 0;
+  padding: 0;
+}
+
+.container-fluid.bottom-nav-buttons
+  div[class*=" col-"]
+  .ember-view
+  .navigation-button {
+  margin: 0 16px 0 0px;
+  padding: 8px 32px;
+}
+
+@media only screen and (max-width: 768px) {
+  .container-fluid.bottom-nav-buttons
+    div[class*=" col-"]
+    .ember-view
+    .navigation-button:not([aria-label="BACK"]) {
+    margin: 0 0px 0 16px;
+    padding: 8px 32px;
+  }
+  .container-fluid.bottom-nav-buttons
+    div[class*=" col-"]
+    .ember-view
+    .navigation-button[aria-label="NEXT"] {
+    margin: 0 0px 0 16px;
+    padding: 8px 32px;
+  }
+}
+
+/*---- Collapse / Toggle styles ----*/
+
+.panel.panel-default > .panel-heading,
+.panel > .panel-heading {
+  background-color: transparent;
+  border-bottom: 1px solid #666666;
+  margin-bottom: 16px;
+}
+
+.expansion-toggle.primary-accent-bg {
+  background-color: #5489a3;
+  color: #fff !important;
+  font-size: 2rem;
+  font-weight: bold;
+}
+
+.expansion-toggle:focus {
+  outline: 2px solid currentColor;
+  outline-offset: -0.25em;
+}
+
+.container-fluid.bottom-nav-buttons {
+  display: flex;
+  flex-direction: row;
+  padding-left: 0;
+}
+
+/* Fix page padding */
+.main {
+  padding: 8px;
+}
+
+a {
+  color: #1c2745;
+}
+
+.prompt-box a,
+.panel.body a {
+  color: #1c2745;
+  font-style: normal;
+  font-weight: 700;
+}
+
+/* Favorite icon */
+i.material-icons.favorite {
+  color: #ffcda4;
+}
+
+/* Remove box shadows */
+.survey-page textarea.ember-text-area.form-control {
+  box-shadow: none;
+  background-color: #fff;
+}
+
+/* Improve appearance of drop shadows */
+.btn.btn-raised:not(.btn-link) {
+  box-shadow: none;
+}
+
+.dropdown .comment-privacy-select .open {
+  box-shadow: none;
+}
+/*---- Panels ----*/
+
+div[class*="-column"] .panel {
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.12), 0 1px 2px 0 rgba(0, 0, 0, 0.12);
+}
+
+[role="main"] .panel {
+  background: transparent;
+  box-shadow: none;
+}
+
+/*---- Input text and textarea ----*/
+
+.form-control,
+.form-group .form-control {
+  border: 2px solid #d1d1d1;
+  border-radius: 0.25em;
+  background-image: none;
+  padding: 0.5em;
+  height: auto;
+  background-color: #fff;
+}
+
+/* fix radio button / checkbox hover effect on textboxes and textareas */
+.form-group.qradio.is-focused input[type="text"],
+.form-group.qradio.is-focused textarea,
+.form-group.qcheckbox.is-focused input[type="text"],
+.form-group.qcheckbox.is-focused textarea {
+  background-image: none;
+}
+
+.radio span,
+label.radio-inline span {
+  top: 6px !important;
+}
+
+.page-survey-page .panel-body + div.form-group {
+  padding: 2em;
+  background-color: #ffffff;
+}
+
+div:has(> .form-group) + div {
+  margin-top: 1em;
+}
+
+.form-group p {
+  margin-bottom: 0.25em !important;
+}
+
+.form-comment .form-group {
+  margin-top: 0.25em;
+}
+
+/* Progress bar */
+.progress-bar-voting {
+  padding-right: 2px;
+}
+
+.progress-bar-voting .progress-bar-voting__circle {
+  border: 3px solid #1c2745;
+  width: 69px;
+  height: 69px;
+  font-size: 22px;
+  line-height: 60px;
+  margin-top: -26px;
+  margin-left: 2px;
+  background-color: #1c2745;
+  color: #fff;
+  padding-left: 4px;
+}
+
+.progress-bar-voting .progress-bar-voting__circle {
+  right: -2px;
+}
+
+.progress-bar-voting__circle {
+  margin-left: 4px;
+}
+
+.progress-bar-voting {
+  background-color: #e79450;
+}
+
+.progress-bar-voting .progress-bar-voting__fill {
+  background-color: #1c2745;
+  border-radius: 0px;
+}
+
+.progress-bar-voting span {
+  font-weight: 700;
+  letter-spacing: -0.266px;
+}
+
+section p,
+section li {
+  line-height: 1.7rem;
+}
+
+/*---- Likert overrides ----*/
+.panel:has(.likert-container) {
+  background: #fff;
+}
+
+.likert-container .ethelo-likert-group {
+  align-items: flex-start;
+}
+
+.ethelo-likert-group li.ethelo-likert-button-container .ethelo-likert-subtext,
+.ethelo-voted-label li.ethelo-likert-button-container .ethelo-likert-subtext {
+  display: block;
+  font-size: 1.2rem !important;
+  line-height: 1.5 !important;
+  margin-top: 0.75em;
+  text-transform: none !important;
+  visibility: visible;
+  font-weight: 400;
+}
+
+.ember-view.ethelo-likert-button-container {
+  flex-direction: column-reverse;
+}
+
+.ethelo-likert-subtext {
+  font-weight: bold;
+  text-transform: unset;
+}
+
+.ember-view.ethelo-likert-button-container > a[role="button"] {
+  background: #f6f6f6 !important;
+  border: 2px solid #d1d1d1;
+  border-radius: 50%;
+  display: flex;
+  height: 2em;
+  padding: 1em;
+  width: 2em;
+}
+
+.ember-view.ethelo-likert-button-container.active > .ethelo-likert-subtext {
+  font-weight: bold;
+}
+.ember-view.ethelo-likert-button-container.active > a[role="button"] {
+  border-color: #1c2745;
+  box-shadow: none;
+  padding: 1em;
+}
+
+.ember-view.ethelo-likert-button-container > a[role="button"] [aria-hidden] {
+  display: none;
+}
+
+.ember-view.ethelo-likert-button-container.active
+  > a[role="button"]
+  .ethelo-likert-indicator.hidden-xs.hidden-sm {
+  align-self: center;
+  background: #1c2745;
+  border-radius: 50%;
+  display: block !important;
+  height: unset;
+  margin: 0;
+  order: -1;
+  padding: 0.75em;
+  transform: translate(-0.75em);
+  width: unset;
+}
+
+div:not(.modal-body) .ethelo-likert-label.visible-md.visible-lg {
+  display: none !important;
+}
+.modal-body .ethelo-likert-text {
+  font-weight: normal;
+}
+
+.modal-body
+  .ember-view.ethelo-likert-button-container
+  > a[role="button"]
+  .ethelo-likert-text {
+  align-self: center;
+  color: #000 !important;
+  transform: translateX(2em);
+}
+.modal-body
+  .ember-view.ethelo-likert-button-container.active
+  > a[role="button"]
+  .ethelo-likert-text.visible-xs.visible-sm {
+  font-weight: bold;
+  transform: translateX(0.5em);
+}
+
+/* Remove uppercase text transformations */
+.btn,
+.btn-outline,
+.input-group-btn .btn {
+  text-transform: none;
+}
+
+.list-group-item.comment-item-container .comment-item .user-name {
+  text-transform: none;
+}
+
+/* Fix font colors on results page*/
+.card.result-card .detail-toggle .title {
+  color: #1c2745;
+}
+
+.card.flat .card-body .nav-pills > li > a {
+  color: #1c2745;
+}
+
+.panel-body {
+  padding: 0px;
+}
+
+#questions-panel .panel-body div.ember-view .panel-body:not(.panel-body) {
+  margin-bottom: 60px;
+}
+
+#questions-panel .panel-body div.ember-view .panel-body,
+#questions-panel .panel-body div.ember-view .panel-body + .qcheckbox {
+  margin-bottom: 0px;
+}
+
+.content-col .panel-body {
+  padding: 0px 16px 16px 16px;
+}
+
+.content-col .panel-body li:not(.comments),
+.content-col .panel-body p,
+.content-col .panel-body .option-description {
+  line-height: 170% !important;
+  font-size: 2rem;
+}
+.content-col .panel-body p {
+  margin-bottom: calc(0.7rem + 0.1vw);
+}
+.list-group .list-group-item {
+  padding-left: 0px;
+}
+
+.content-col .panel-body .form-group .control-label p {
+  font-weight: 700;
+  font-size: 2.2rem !important;
+}
+
+.nav-item-container a {
+  padding: 16px;
+}
+.list-group-item .material-icons-outlined {
+  top: 16px;
+  right: 8px;
+}
+.option-description .option-text p {
+  font-weight: 700;
+  margin-bottom: 1em;
+}
+
+/* Override comment styles */
+textarea.ember-text-area.form-control,
+.survey-page textarea.ember-text-area.form-control,
+.qtextarea {
+  margin: 0;
+  padding: 0;
+  box-shadow: none;
+  padding: 1.5em;
+  /* background-color: #fff; */
+  height: auto;
+  min-height: 150px;
+}
+
+.survey-page .form-group {
+  /* padding: 16px 40px; */
+}
+
+.list-group .row-picture img.circle {
+  display: none;
+}
+.comment-item small {
+  font-size: 1.5rem;
+  display: inline-block;
+  margin-right: 0.25em;
+}
+
+.dropdown .comment-privacy-select .open {
+  box-shadow: none;
+}
+.dropdown .comment-privacy-select {
+  line-height: 100%;
+}
+
+.list-group-item.new-comment-container .btn {
+  margin: 10px 24px;
+}
+
+.comments > .comment-item-container > .comment-item {
+  padding-right: 2em;
+}
+
+@media only screen and (max-width: 768px) {
+  .comments > .comment-item-container > .comment-item {
+    padding-right: 16px;
+  }
+  .list-group .list-group-item .row-content {
+    display: inline-block;
+    width: calc(100% - 16px);
+    min-height: 66px;
+  }
+}
+
+.comment-item,
+.comment-item,
+.new-comment-container .form-group {
+  display: flex;
+  align-items: flex-start;
+}
+
+.comment-item:before,
+    /* .new-comment-container .form-group:before,  */
+    .page-survey-page .form-comment-container-outer:before,
+    .page-voting-option-category .form-comment-container-outer:before {
+  content: "";
+  display: inline-block;
+  background-position: center center !important;
+  background-repeat: no-repeat !important;
+  background-size: 65% !important;
+  border-radius: 50%;
+  padding: 2.25rem !important;
+  margin-right: 1rem;
+  background-image: url("https://odi-uploads.s3.us-west-2.amazonaws.com/store/cc73297c0ea1ec5a2622a5e54976f2e1.png");
+}
+
+.likert-container strong.pull-right {
+  text-transform: initial;
+}
+
+button.comment-section-btns,
+.form-comment-container-outer .btn.btn-raised,
+.form-comment-container-outer .btn.btn-raised.btn-default {
+  background-color: #e79450 !important;
+}
+
+.right-sidebar__bottom.panel-group .panel-body {
+  padding: 8px;
+}
+
+.hub-container .panel-body {
+  padding: 16px;
+  background-color: #f0e6dc;
+  margin: 20px 0px;
+  padding: 40px;
+  border-radius: 20px;
+}
+
+.comment-item-container:nth-child(3n + 1) .comment-item:before,
+.comment-replies
+  .comment-item-container:nth-child(3n + 1)
+  .comment-item:before {
+  background-color: #ffcda4;
+}
+
+.comment-item-container:nth-child(3n + 2) .comment-item:before,
+.comment-replies
+  .comment-item-container:nth-child(3n + 2)
+  .comment-item:before {
+  background-color: #fff4eb;
+}
+
+.comment-item-container:nth-child(3n + 3) .comment-item:before {
+  background-color: #91bdd3;
+}
+
+.list-group-item.comment-item-container
+  .comment-item:hover
+  > .row-content
+  .more-actions {
+  right: 1em;
+}
+
+.list-group.comments {
+  margin-bottom: 60px;
+}
+
+.btn.btn-xs {
+  font-size: 16px;
+}
+
+.help-block,
+.form-group .help-block,
+.form-group + .help-block {
+  padding: 16px;
+  background-color: #f0e6dc;
+  margin: 10px 24px;
+  padding: 10px 32px;
+  border-radius: 20px;
+}
+
+/*---- Radio and Checkbox ----*/
+.form-group .checkbox label,
+.form-group .radio label,
+.form-group label {
+  font-size: 2rem;
+}
+
+.checkbox,
+.radio {
+  margin-top: 0px;
+}
+
+.checkbox .checkbox-material,
+label.checkbox-inline .checkbox-material {
+  padding-right: 16px;
+}
+
+.radio + .radio,
+.checkbox > br + label {
+  margin-top: 0.5em;
+}
+
+.checkbox-group,
+.radio-group {
+  margin-bottom: 1em;
+}
+
+.form-group .dropdown:not(.comment-privacy-select, .more-actions) {
+  width: 100%;
+  min-width: 15ch;
+  max-width: 30ch;
+  border: 2px solid #d1d1d1;
+  border-radius: 0.25em;
+  font-size: 1.5rem;
+  cursor: pointer;
+  background-color: #fff;
+  align-items: center;
+  padding: 0.75em;
+  display: flex;
+  margin-bottom: 16px;
+}
+
+.form-group .dropdown:not(.comment-privacy-select, .more-actions) .x-select {
+  outline: none;
+
+  background: transparent;
+  border: none;
+  padding: 0 1em 0 0;
+  margin: 0;
+  width: 100%;
+  font-family: inherit;
+  font-size: inherit;
+  cursor: inherit;
+  line-height: inherit;
+  transform: scaleX(108%) translateX(0.4em);
+}
+
+.x-select::-ms-expand {
+  display: none;
+}
+
+.form-group .dropdown::after {
+  content: "";
+  width: 0.8em;
+  height: 0.5em;
+  background-color: #548097;
+  clip-path: polygon(100% 0%, 0 0%, 50% 100%);
+  justify-self: end;
+}
+
+/* Commenting ----*/
+.comment-privacy-select {
+  display: none !important;
+}
+.comment-like-count {
+  vertical-align: baseline;
+}
+.flag-count {
+  display: none;
+}
+
+/*-- fix next button bug (test) --*/
+.container-fluid.bottom-nav-buttons * {
+  float: none !important;
+  width: auto !important;
+}
+
+.container-fluid.bottom-nav-buttons .btn {
+  max-width: 9em; /* Don't let next button get too wide */
+}
+
+.container-fluid.bottom-nav-buttons .row.inner {
+  display: flex;
+  flex-direction: row;
+}
+

--- a/scripts/ethelo-css/los-angeles-fires-recovery/tell-us-your-recovery-priorities-development.css
+++ b/scripts/ethelo-css/los-angeles-fires-recovery/tell-us-your-recovery-priorities-development.css
@@ -1,0 +1,1138 @@
+/* Instance specific CSS */
+.panel-body.signin-form::before,
+.invited-panel .panel-body::before {
+  content: "You have been invited to tell us your Los Angeles fires recovery priorities." !important;
+}
+
+/* Demo mode UX improvements */
+.new-comment .form-comment-container-outer {
+  display: none !important;
+}
+
+/* New styles to organize into rest of stylesheet */
+.nav-item-container.list-group-item ul.list-group .nav-item-container a {
+  padding-left: 40px !important;
+}
+
+.prompt {
+  font-size: 2rem;
+}
+
+.prompt-box {
+  background-color: #f0e6dc;
+  margin: 20px 0px;
+  padding: 40px;
+  border-radius: 20px;
+}
+
+span.bigger-emoji {
+  font-size: 4.4rem;
+}
+
+/* remove client feedback button */
+a.client-feedback {
+  display: none;
+}
+
+.top-navigation-btn {
+  display: none;
+}
+
+.navbar-brand img.custom-logo.visible-xs-inline {
+  max-height: 50px;
+}
+
+.visible-xs.visible-sm.navbar-brand.decision-title {
+  margin-top: 10px;
+}
+
+.comment-section-btns.btn-xs {
+  margin-left: 32px;
+}
+
+.form-group .help-block {
+  position: relative;
+}
+
+/*--- Sign in form ----*/
+
+.signin-form strong {
+  display: none;
+}
+
+.signin-form p {
+  font-weight: 700;
+  font-size: 2.2rem !important;
+}
+
+#auth-modal-label {
+  display: none;
+}
+
+/* Comment title styling  */
+
+.instruct p {
+  font-weight: 700;
+  font-size: 2rem !important;
+}
+
+/*---- Account ----*/
+#edit-profile .form-group:has([name="username"]) {
+  display: none;
+}
+
+#edit-profile .form-group:has([name="username"]) input {
+  opacity: 0.3;
+}
+
+/* -- User profile menu ----*/
+li.navbar-user-dropdown {
+  display: none !important;
+}
+
+/*---- Invited panel ----*/
+.invited-panel .panel-body p {
+  display: none;
+}
+
+.panel-body.signin-form::before,
+.invited-panel .panel-body::before {
+  font-weight: 700;
+  font-size: 2.2rem !important;
+  padding-bottom: 60px;
+}
+.panel-body.signin-form p:first-child,
+.invited-panel .panel-footer {
+  display: none;
+}
+
+/*---- Typography ----*/
+
+/*---- Spacing and Layout ----*/
+p + p,
+.comment-item-container + .comment-item-container,
+.ethelo-likert-group,
+.form-group.row {
+  margin-top: 1.5em;
+}
+
+.comment-replies {
+  padding-left: 20px;
+}
+
+.hide-comments {
+  right: 0;
+}
+
+.page-voting-option-category .likert-container {
+  padding: 16px 40px;
+}
+
+.page-voting-option-category .likert-container .ember-view {
+  padding-bottom: 0px;
+}
+
+.comment-item-container .row-content .list-group-item-text {
+  margin-top: 0.25em;
+  margin-bottom: 0;
+}
+
+.form-group .pull-right {
+  float: none !important;
+}
+
+hr.fancy {
+  border: 0;
+  margin: 40px 0 0 0 !important;
+  height: 1px;
+  background-image: linear-gradient(
+    to right,
+    rgba(0, 0, 0, 0.25),
+    rgba(0, 0, 0, 0.25),
+    rgba(0, 0, 0, 0.25)
+  );
+}
+
+/*---- Other ----*/
+li.navbar-user-dropdown {
+  display: block;
+}
+
+li.navbar-user-dropdown span[aria-label="User Menu"] {
+  color: #1c2745;
+}
+
+li.navbar-user-dropdown span[aria-label="User Menu"]:hover {
+  color: #1c2745;
+}
+
+/* Hide User name and sign up boxes in login */
+label[for="auth_name"] {
+  display: none;
+}
+input#auth_name {
+  display: none;
+}
+
+.sign-checkbox .info label {
+  display: none;
+  padding-bottom: 100px;
+}
+
+#signup-page-text p img {
+  content: url("https://engaged.ca.gov/public/images/header-logo.svg");
+}
+
+.untabbed-modal-panel .checkbox.bottom-0 label {
+  display: none;
+}
+
+.list-group-item.comment-item-container .comment-item .user-name {
+  display: none;
+}
+
+.signon {
+  margin: 40px;
+}
+
+.untabbed-modal-panel .panel-body p {
+  margin-top: 16px;
+  font-size: 120%;
+  font-weight: 700;
+  line-height: 1.275;
+}
+
+.untabbed-modal-panel .panel-body label.info {
+  font-size: 120%;
+  line-height: 1.275;
+}
+
+.untabbed-modal-panel .panel-footer {
+  font-size: 120%;
+  line-height: 1.275;
+}
+
+.untabbed-modal-panel .panel-body label.info a {
+  font-size: inherit;
+  line-height: 1.275;
+  color: #5489a3;
+  text-decoration: underline;
+}
+
+strong#auth-modal-label {
+  font-size: 170%;
+  letter-spacing: -0.015em;
+  font-family: "Noto Sans", sans-serif;
+  font-weight: 900;
+  line-height: 120%;
+}
+
+.form-group.has-error .help-block,
+.form-group.has-error label.control-label {
+  color: #ffcda4;
+  position: relative;
+  margin-top: 16px;
+}
+
+/* Match fonts colors default to engaged.ca.gov */
+body
+  *:not(
+    .h4.panel-slider__title > .float-left,
+    .material-icons-outlined,
+    .material-icons,
+    .person,
+    .icon
+  ) {
+  font-family: "Noto Sans", system-ui, sans-serif !important;
+}
+
+h1,
+h2,
+h3,
+.h4.panel-slider__title > .float-left,
+.display-text {
+  letter-spacing: -0.015em;
+  font-family: "Noto Sans", sans-serif;
+  font-weight: 900;
+  line-height: 150%;
+}
+.navbar .navbar-brand {
+  color: #1c2745;
+  height: 80px;
+  line-height: 47px;
+}
+
+.nav-item.active {
+  background-color: #FFCDA4;
+}
+
+.list-group-item .material-icons-outlined.half-complete {
+  color: #6c757d;
+}
+.panel-slider__title {
+  font-size: 2.4rem;
+}
+
+#page-header {
+  width: 100%;
+  text-align: left;
+  margin: 0;
+  vertical-align: middle;
+  padding-bottom: 0px;
+}
+
+b,
+strong {
+  font-weight: 700;
+}
+
+body {
+  background-color: #f3f3f3;
+}
+
+/* Change navbar background */
+.navbar.primary-accent-bg,
+.navbar.navbar-default.primary-accent-bg {
+  background-color: #ffffff;
+}
+
+/* Change navbar title color */
+.navbar .navbar-nav > li.decision-title,
+.navbar .navbar-nav > li > a {
+  color: #000;
+  font-family: "Noto Sans";
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 150%; /* 36px */
+  letter-spacing: -0.264px;
+}
+
+/* Match navbar background color for user dropdown */
+.navbar-user-dropdown {
+  background-color: #ffffff;
+}
+
+/* Adjust required style */
+.required {
+  font-style: normal;
+  text-decoration: none;
+  color: #fd7e14;
+  float: left !important;
+  margin-right: 8px;
+  margin-top: 0.9rem;
+  display: inline-block;
+}
+
+.control-label .required {
+  margin-top: 0rem;
+}
+
+.required + h2 {
+  display: flex;
+  float: none !important;
+  margin-bottom: 16px;
+}
+
+/* Fix responsive navbar */
+
+.navbar .navbar-brand,
+.custom-logo {
+  height: auto;
+  padding: 0 15px 10px 15px;
+  line-height: 2.5em;
+}
+
+.h1,
+h1 {
+  font-size: 3.2rem;
+}
+
+.h2,
+h2 {
+  font-size: 2.3rem;
+}
+
+.h1,
+.h2,
+.h3,
+h1,
+h2,
+h3 {
+  margin-top: 0.9rem;
+  margin-bottom: 0.9rem;
+}
+
+.navbar .navbar-brand,
+.custom-logo {
+  padding: 0px;
+}
+
+.navbar-brand {
+  color: #000;
+  font-family: "Noto Sans";
+  /* font-size: 1.2rem; */
+  font-style: normal;
+  font-weight: 500;
+  line-height: 126%; /* 22.68px */
+  letter-spacing: -0.198px;
+  display: block;
+}
+.navbar .navbar-nav > li.decision-title,
+.navbar-brand.decision-title {
+  margin-right: 40px;
+  white-space: initial;
+  overflow: visible;
+  text-overflow: initial;
+  line-height: 1.25rem;
+  margin-top: 20px;
+  margin-left: 15px;
+  padding: 10px;
+}
+
+@media only screen and (max-width: 992px) {
+  .navbar-brand {
+    font-size: 1.4rem;
+  }
+
+  .navbar-brand {
+    font-size: 1.4rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 126%; /* 22.68px */
+    letter-spacing: -0.198px;
+    display: block;
+  }
+  .navbar .navbar-nav > li.decision-title,
+  .navbar-brand.decision-title {
+    margin-right: 40px;
+    white-space: initial;
+    overflow: auto;
+    text-overflow: initial;
+    line-height: 1.25rem;
+    margin-top: 20px;
+    padding: 10px;
+  }
+}
+
+/* Form overrides */
+.qcheckbox p {
+  font-size: 23px;
+  /* font-weight: 700; */
+  line-height: 1.275;
+}
+
+/* Slider style overrides */
+.qlabeled_slider .control-label p {
+  font-size: 23px;
+  font-weight: 700;
+  line-height: 1.275;
+}
+
+.qlabeled_slider .control-label .required {
+  line-height: 1.275;
+  margin-bottom: 16px;
+}
+
+.form-control.survey-labeled-slider {
+  margin-top: 32px;
+}
+
+.qlabeled_slider.row {
+  margin-bottom: 48px;
+}
+
+.labeled-slider .slider .tooltip-inner::before,
+.range-slider .slider .tooltip-inner::before,
+.survey-slider .slider .tooltip-inner::before,
+.weighting-slider .slider .tooltip-inner::before {
+  content: "Use slider to vote";
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  color: #1c2745;
+  background: #fcb880;
+  border: none;
+  border-radius: 4px;
+  white-space: nowrap;
+  max-width: none;
+  text-align: center;
+  line-height: 19px;
+  left: 0;
+  top: 0;
+  padding: 0 5px;
+}
+
+/* Make it easier to see the modal close button */
+button.close i.material-icons {
+  color: #1c2745;
+}
+
+button.close {
+  opacity: 1;
+}
+
+/*-- Buttons --*/
+.btn.btn-raised.btn-primary,
+.btn.btn-raised.btn-danger,
+.btn.navigation-button,
+.btn.ethelo-likert-group-mobile {
+  background-color: #e79450 !important;
+  color: #1c2745;
+  text-transform: lowercase;
+  font-size: 1.65rem;
+  border-radius: 0.625rem;
+  padding: 0.5em 2.5em;
+  letter-spacing: -0.015em;
+  font-family: "Noto Sans", sans-serif;
+  font-weight: 400;
+  border: 2px solid transparent;
+  transition: none;
+}
+
+.btn.btn-raised.btn-danger {
+  background-color: #fff !important;
+  color: #1c2745;
+  border: 2px solid #d24532;
+}
+
+.btn.btn-raised.btn-primary:hover,
+.btn.btn-raised.btn-primary:active {
+  background-color: #e79450;
+}
+
+.btn.btn-raised.btn-danger::first-letter,
+.btn.btn-raised.btn-primary::first-letter,
+.btn.navigation-button::first-letter,
+.btn.ethelo-likert-group-mobile::first-letter {
+  text-transform: uppercase !important;
+}
+
+.bottom-nav-buttons > .row .btn.navigation-button:not([aria-disabled="true"]),
+.btn.ethelo-likert-group-mobile {
+  border-radius: 0.625rem;
+  border: 2px solid #e79450;
+}
+
+.bottom-nav-buttons > .row > div:first-child .btn.navigation-button {
+  background: #fff !important;
+  color: #000;
+}
+
+.bottom-nav-buttons .btn.navigation-button:focus,
+.btn.ethelo-likert-group-mobile:focus {
+  border: 2px solid #e79450 !important;
+  outline: 1px solid #000 !important;
+}
+
+.bottom-nav-buttons > .row .btn.navigation-button[aria-label="NEXT"] {
+  background-color: #e79450;
+  color: #1c2745;
+  font-weight: 700;
+}
+
+.btn.navigation-button[aria-disabled="true"] {
+  border: 2px solid #ddd;
+  background-color: #f2f2f2 !important;
+  color: rgba(148, 152, 155, 0.85) !important;
+}
+
+button.btn:focus,
+button.btn.btn-raised.navigation-button.btn-primary:focus {
+  border: inherit !important;
+}
+
+.bottom-nav-buttons > .row .navigation-button:hover {
+  background-color: inherit;
+}
+
+.container-fluid.bottom-nav-buttons {
+  display: flex;
+  flex-direction: row;
+  padding-left: 0;
+}
+
+/* Remove all padding */
+.container-fluid.bottom-nav-buttons div[class*=" col-"] {
+  margin: 0;
+  padding: 0;
+}
+
+.container-fluid.bottom-nav-buttons
+  div[class*=" col-"]
+  .ember-view
+  .navigation-button {
+  margin: 0 16px 0 0px;
+  padding: 8px 32px;
+}
+
+@media only screen and (max-width: 768px) {
+  .container-fluid.bottom-nav-buttons
+    div[class*=" col-"]
+    .ember-view
+    .navigation-button:not([aria-label="BACK"]) {
+    margin: 0 0px 0 16px;
+    padding: 8px 32px;
+  }
+  .container-fluid.bottom-nav-buttons
+    div[class*=" col-"]
+    .ember-view
+    .navigation-button[aria-label="NEXT"] {
+    margin: 0 0px 0 16px;
+    padding: 8px 32px;
+  }
+}
+
+/*---- Collapse / Toggle styles ----*/
+
+.panel.panel-default > .panel-heading,
+.panel > .panel-heading {
+  background-color: transparent;
+  border-bottom: 1px solid #666666;
+  margin-bottom: 16px;
+}
+
+.expansion-toggle.primary-accent-bg {
+  background-color: #5489a3;
+  color: #fff !important;
+  font-size: 2rem;
+  font-weight: bold;
+}
+
+.expansion-toggle:focus {
+  outline: 2px solid currentColor;
+  outline-offset: -0.25em;
+}
+
+.container-fluid.bottom-nav-buttons {
+  display: flex;
+  flex-direction: row;
+  padding-left: 0;
+}
+
+/* Fix page padding */
+.main {
+  padding: 8px;
+}
+
+a {
+  color: #1c2745;
+}
+
+.prompt-box a,
+.panel.body a {
+  color: #1c2745;
+  font-style: normal;
+  font-weight: 700;
+}
+
+/* Favorite icon */
+i.material-icons.favorite {
+  color: #ffcda4;
+}
+
+/* Remove box shadows */
+.survey-page textarea.ember-text-area.form-control {
+  box-shadow: none;
+  background-color: #fff;
+}
+
+/* Improve appearance of drop shadows */
+.btn.btn-raised:not(.btn-link) {
+  box-shadow: none;
+}
+
+.dropdown .comment-privacy-select .open {
+  box-shadow: none;
+}
+/*---- Panels ----*/
+
+div[class*="-column"] .panel {
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.12), 0 1px 2px 0 rgba(0, 0, 0, 0.12);
+}
+
+[role="main"] .panel {
+  background: transparent;
+  box-shadow: none;
+}
+
+/*---- Input text and textarea ----*/
+
+.form-control,
+.form-group .form-control {
+  border: 2px solid #d1d1d1;
+  border-radius: 0.25em;
+  background-image: none;
+  padding: 0.5em;
+  height: auto;
+  background-color: #fff;
+}
+
+/* fix radio button / checkbox hover effect on textboxes and textareas */
+.form-group.qradio.is-focused input[type="text"],
+.form-group.qradio.is-focused textarea,
+.form-group.qcheckbox.is-focused input[type="text"],
+.form-group.qcheckbox.is-focused textarea {
+  background-image: none;
+}
+
+.radio span,
+label.radio-inline span {
+  top: 6px !important;
+}
+
+.page-survey-page .panel-body + div.form-group {
+  padding: 2em;
+  background-color: #ffffff;
+}
+
+div:has(> .form-group) + div {
+  margin-top: 1em;
+}
+
+.form-group p {
+  margin-bottom: 0.25em !important;
+}
+
+.form-comment .form-group {
+  margin-top: 0.25em;
+}
+
+/* Progress bar */
+.progress-bar-voting {
+  padding-right: 2px;
+}
+
+.progress-bar-voting .progress-bar-voting__circle {
+  border: 3px solid #1c2745;
+  width: 69px;
+  height: 69px;
+  font-size: 22px;
+  line-height: 60px;
+  margin-top: -26px;
+  margin-left: 2px;
+  background-color: #1c2745;
+  color: #fff;
+  padding-left: 4px;
+}
+
+.progress-bar-voting .progress-bar-voting__circle {
+  right: -2px;
+}
+
+.progress-bar-voting__circle {
+  margin-left: 4px;
+}
+
+.progress-bar-voting {
+  background-color: #e79450;
+}
+
+.progress-bar-voting .progress-bar-voting__fill {
+  background-color: #1c2745;
+  border-radius: 0px;
+}
+
+.progress-bar-voting span {
+  font-weight: 700;
+  letter-spacing: -0.266px;
+}
+
+section p,
+section li {
+  line-height: 1.7rem;
+}
+
+/*---- Likert overrides ----*/
+.panel:has(.likert-container) {
+  background: #fff;
+}
+
+.likert-container .ethelo-likert-group {
+  align-items: flex-start;
+}
+
+.ethelo-likert-group li.ethelo-likert-button-container .ethelo-likert-subtext,
+.ethelo-voted-label li.ethelo-likert-button-container .ethelo-likert-subtext {
+  display: block;
+  font-size: 1.2rem !important;
+  line-height: 1.5 !important;
+  margin-top: 0.75em;
+  text-transform: none !important;
+  visibility: visible;
+  font-weight: 400;
+}
+
+.ember-view.ethelo-likert-button-container {
+  flex-direction: column-reverse;
+}
+
+.ethelo-likert-subtext {
+  font-weight: bold;
+  text-transform: unset;
+}
+
+.ember-view.ethelo-likert-button-container > a[role="button"] {
+  background: #f6f6f6 !important;
+  border: 2px solid #d1d1d1;
+  border-radius: 50%;
+  display: flex;
+  height: 2em;
+  padding: 1em;
+  width: 2em;
+}
+
+.ember-view.ethelo-likert-button-container.active > .ethelo-likert-subtext {
+  font-weight: bold;
+}
+.ember-view.ethelo-likert-button-container.active > a[role="button"] {
+  border-color: #1c2745;
+  box-shadow: none;
+  padding: 1em;
+}
+
+.ember-view.ethelo-likert-button-container > a[role="button"] [aria-hidden] {
+  display: none;
+}
+
+.ember-view.ethelo-likert-button-container.active
+  > a[role="button"]
+  .ethelo-likert-indicator.hidden-xs.hidden-sm {
+  align-self: center;
+  background: #1c2745;
+  border-radius: 50%;
+  display: block !important;
+  height: unset;
+  margin: 0;
+  order: -1;
+  padding: 0.75em;
+  transform: translate(-0.75em);
+  width: unset;
+}
+
+div:not(.modal-body) .ethelo-likert-label.visible-md.visible-lg {
+  display: none !important;
+}
+.modal-body .ethelo-likert-text {
+  font-weight: normal;
+}
+
+.modal-body
+  .ember-view.ethelo-likert-button-container
+  > a[role="button"]
+  .ethelo-likert-text {
+  align-self: center;
+  color: #000 !important;
+  transform: translateX(2em);
+}
+.modal-body
+  .ember-view.ethelo-likert-button-container.active
+  > a[role="button"]
+  .ethelo-likert-text.visible-xs.visible-sm {
+  font-weight: bold;
+  transform: translateX(0.5em);
+}
+
+/* Remove uppercase text transformations */
+.btn,
+.btn-outline,
+.input-group-btn .btn {
+  text-transform: none;
+}
+
+.list-group-item.comment-item-container .comment-item .user-name {
+  text-transform: none;
+}
+
+/* Fix font colors on results page*/
+.card.result-card .detail-toggle .title {
+  color: #1c2745;
+}
+
+.card.flat .card-body .nav-pills > li > a {
+  color: #1c2745;
+}
+
+.panel-body {
+  padding: 0px;
+}
+
+#questions-panel .panel-body div.ember-view .panel-body:not(.panel-body) {
+  margin-bottom: 60px;
+}
+
+#questions-panel .panel-body div.ember-view .panel-body,
+#questions-panel .panel-body div.ember-view .panel-body + .qcheckbox {
+  margin-bottom: 0px;
+}
+
+.content-col .panel-body {
+  padding: 0px 16px 16px 16px;
+}
+
+.content-col .panel-body li:not(.comments),
+.content-col .panel-body p,
+.content-col .panel-body .option-description {
+  line-height: 170% !important;
+  font-size: 2rem;
+}
+.content-col .panel-body p {
+  margin-bottom: calc(0.7rem + 0.1vw);
+}
+.list-group .list-group-item {
+  padding-left: 0px;
+}
+
+.content-col .panel-body .form-group .control-label p {
+  font-weight: 700;
+  font-size: 2.2rem !important;
+}
+
+.nav-item-container a {
+  padding: 16px;
+}
+.list-group-item .material-icons-outlined {
+  top: 16px;
+  right: 8px;
+}
+.option-description .option-text p {
+  font-weight: 700;
+  margin-bottom: 1em;
+}
+
+/* Override comment styles */
+textarea.ember-text-area.form-control,
+.survey-page textarea.ember-text-area.form-control,
+.qtextarea {
+  margin: 0;
+  padding: 0;
+  box-shadow: none;
+  padding: 1.5em;
+  /* background-color: #fff; */
+  height: auto;
+  min-height: 150px;
+}
+
+.survey-page .form-group {
+  /* padding: 16px 40px; */
+}
+
+.list-group .row-picture img.circle {
+  display: none;
+}
+.comment-item small {
+  font-size: 1.5rem;
+  display: inline-block;
+  margin-right: 0.25em;
+}
+
+.dropdown .comment-privacy-select .open {
+  box-shadow: none;
+}
+.dropdown .comment-privacy-select {
+  line-height: 100%;
+}
+
+.list-group-item.new-comment-container .btn {
+  margin: 10px 24px;
+}
+
+.comments > .comment-item-container > .comment-item {
+  padding-right: 2em;
+}
+
+@media only screen and (max-width: 768px) {
+  .comments > .comment-item-container > .comment-item {
+    padding-right: 16px;
+  }
+  .list-group .list-group-item .row-content {
+    display: inline-block;
+    width: calc(100% - 16px);
+    min-height: 66px;
+  }
+}
+
+.comment-item,
+.comment-item,
+.new-comment-container .form-group {
+  display: flex;
+  align-items: flex-start;
+}
+
+.comment-item:before,
+    /* .new-comment-container .form-group:before,  */
+    .page-survey-page .form-comment-container-outer:before,
+    .page-voting-option-category .form-comment-container-outer:before {
+  content: "";
+  display: inline-block;
+  background-position: center center !important;
+  background-repeat: no-repeat !important;
+  background-size: 65% !important;
+  border-radius: 50%;
+  padding: 2.25rem !important;
+  margin-right: 1rem;
+  background-image: url("https://odi-uploads.s3.us-west-2.amazonaws.com/store/cc73297c0ea1ec5a2622a5e54976f2e1.png");
+}
+
+.likert-container strong.pull-right {
+  text-transform: initial;
+}
+
+button.comment-section-btns,
+.form-comment-container-outer .btn.btn-raised,
+.form-comment-container-outer .btn.btn-raised.btn-default {
+  background-color: #e79450 !important;
+}
+
+.right-sidebar__bottom.panel-group .panel-body {
+  padding: 8px;
+}
+
+.hub-container .panel-body {
+  padding: 16px;
+  background-color: #f0e6dc;
+  margin: 20px 0px;
+  padding: 40px;
+  border-radius: 20px;
+}
+
+.comment-item-container:nth-child(3n + 1) .comment-item:before,
+.comment-replies
+  .comment-item-container:nth-child(3n + 1)
+  .comment-item:before {
+  background-color: #ffcda4;
+}
+
+.comment-item-container:nth-child(3n + 2) .comment-item:before,
+.comment-replies
+  .comment-item-container:nth-child(3n + 2)
+  .comment-item:before {
+  background-color: #fff4eb;
+}
+
+.comment-item-container:nth-child(3n + 3) .comment-item:before {
+  background-color: #91bdd3;
+}
+
+.list-group-item.comment-item-container
+  .comment-item:hover
+  > .row-content
+  .more-actions {
+  right: 1em;
+}
+
+.list-group.comments {
+  margin-bottom: 60px;
+}
+
+.btn.btn-xs {
+  font-size: 16px;
+}
+
+.help-block,
+.form-group .help-block,
+.form-group + .help-block {
+  padding: 16px;
+  background-color: #f0e6dc;
+  margin: 10px 24px;
+  padding: 10px 32px;
+  border-radius: 20px;
+}
+
+/*---- Radio and Checkbox ----*/
+.form-group .checkbox label,
+.form-group .radio label,
+.form-group label {
+  font-size: 2rem;
+}
+
+.checkbox,
+.radio {
+  margin-top: 0px;
+}
+
+.checkbox .checkbox-material,
+label.checkbox-inline .checkbox-material {
+  padding-right: 16px;
+}
+
+.radio + .radio,
+.checkbox > br + label {
+  margin-top: 0.5em;
+}
+
+.checkbox-group,
+.radio-group {
+  margin-bottom: 1em;
+}
+
+.form-group .dropdown:not(.comment-privacy-select, .more-actions) {
+  width: 100%;
+  min-width: 15ch;
+  max-width: 30ch;
+  border: 2px solid #d1d1d1;
+  border-radius: 0.25em;
+  font-size: 1.5rem;
+  cursor: pointer;
+  background-color: #fff;
+  align-items: center;
+  padding: 0.75em;
+  display: flex;
+  margin-bottom: 16px;
+}
+
+.form-group .dropdown:not(.comment-privacy-select, .more-actions) .x-select {
+  outline: none;
+
+  background: transparent;
+  border: none;
+  padding: 0 1em 0 0;
+  margin: 0;
+  width: 100%;
+  font-family: inherit;
+  font-size: inherit;
+  cursor: inherit;
+  line-height: inherit;
+  transform: scaleX(108%) translateX(0.4em);
+}
+
+.x-select::-ms-expand {
+  display: none;
+}
+
+.form-group .dropdown::after {
+  content: "";
+  width: 0.8em;
+  height: 0.5em;
+  background-color: #548097;
+  clip-path: polygon(100% 0%, 0 0%, 50% 100%);
+  justify-self: end;
+}
+
+/* Commenting ----*/
+.comment-privacy-select {
+  display: none !important;
+}
+.comment-like-count {
+  vertical-align: baseline;
+}
+.flag-count {
+  display: none;
+}
+
+/*-- fix next button bug (test) --*/
+.container-fluid.bottom-nav-buttons * {
+  float: none !important;
+  width: auto !important;
+}
+
+.container-fluid.bottom-nav-buttons .btn {
+  max-width: 9em; /* Don't let next button get too wide */
+}
+
+.container-fluid.bottom-nav-buttons .row.inner {
+  display: flex;
+  flex-direction: row;
+}
+

--- a/scripts/ethelo-css/los-angeles-fires-recovery/tell-us-your-recovery-priorities-production.css
+++ b/scripts/ethelo-css/los-angeles-fires-recovery/tell-us-your-recovery-priorities-production.css
@@ -1,13 +1,27 @@
 /* remove client feedback button */
 a.client-feedback {display: none; }
 
+
+/* Prompt */
+
+.prompt {
+  font-size: 2rem;
+}
+
+.prompt-box {
+  background-color: #f0e6dc;
+  margin: 20px 0px;
+  padding: 40px;
+  border-radius: 20px;
+}
+
 /*--- Sign in form ----*/
 
 .signin-form strong {
   display: none;
 }
 
-.signin-form p {
+.signin-form p { 
   font-weight: 700;
   font-size: 2.2rem !important;
 }
@@ -17,7 +31,7 @@ a.client-feedback {display: none; }
 }
 
 
-/*---- Account ----*/
+/*---- Account ----*/ 
 #edit-profile .form-group:has([name="username"]) {
   display: none;
 }
@@ -34,7 +48,7 @@ li.navbar-user-dropdown {
 
 
 
-/*---- Invited panel ----*/
+/*---- Invited panel ----*/ 
 .invited-panel .panel-body p {
    display:none;
 }
@@ -50,12 +64,12 @@ display: none;
 }
 
 
-/*---- Typography ----*/
+/*---- Typography ----*/ 
 
 
 /*---- Spacing and Layout ----*/
-p + p,
-.comment-item-container + .comment-item-container,
+p + p, 
+.comment-item-container + .comment-item-container, 
 .ethelo-likert-group,
 .form-group > * + * {
 margin-top: 1.5em;
@@ -74,16 +88,13 @@ margin-bottom: 0;
 float: none !important;
 }
 
-.form-group .help-block,
+.form-group .help-block, 
 .form-group + .help-block {
     background: transparent;
    padding: 0.25em;
    position: relative;
 }
 
-.qtextarea {
-  background-color: #fff;
-}
 /*---- Other ----*/
 li.navbar-user-dropdown {
   display: block;
@@ -128,13 +139,13 @@ input#auth_name { display: none }
   font-weight: 700;
   line-height: 1.275;
 }
-
+ 
 .untabbed-modal-panel .panel-body label.info {
   font-size: 120%;
   line-height: 1.275;
 }
 
-.untabbed-modal-panel .panel-footer {
+.untabbed-modal-panel .panel-footer { 
   font-size: 120%;
   line-height: 1.275;
 }
@@ -155,7 +166,7 @@ strong#auth-modal-label {
 }
 
 .form-group.has-error .help-block, .form-group.has-error label.control-label {
-    color: #FFCDA4;
+    color: #E79450;
     position: relative;
     margin-top: 16px;
 }
@@ -179,15 +190,13 @@ h3,
   letter-spacing: -0.015em;
   font-family: "Noto Sans", sans-serif;
   font-weight: 900;
-  line-height: 150%;
+  line-height: 120%;
 }
 .navbar .navbar-brand  {
   color: #1c2745;
-  height: 80px;
-  line-height: 47px;
 }
 .nav-item.active {
-  background-color: #E79450;
+  background-color: #FFCDA4;
 }
 
 .list-group-item .material-icons-outlined.half-complete {
@@ -211,7 +220,7 @@ strong {
 }
 
 body {
-  background-color: #f3f3f3;
+  background-color: #fff4eb;
 }
 
 /* Change navbar background */
@@ -224,8 +233,6 @@ body {
 .navbar .navbar-nav > li.decision-title,
 .navbar .navbar-nav > li > a {
   color: #444444;
-  line-height: 47px;
-  font-size: 36px;
 }
 
 /* Match navbar background color for user dropdown */
@@ -247,21 +254,6 @@ body {
 @media only screen and (min-width: 992px) {
   .top-navigation-btn.ember-view {
     display: none;
-  }
-}
-
-@media only screen and (max-width: 1199px) {
-  .navbar .navbar-brand, .custom-logo {
-    height: auto;
-    padding: 0 15px 10px 15px;
-    line-height: 2.5em;
-  }
-  .h1, .h2, h1, h2  {
-    font-size: 2.5rem;
-  }
-  .h1, .h2, .h3, h1, h2, h3 {
-    margin-top: .9rem;
-    margin-bottom: .9rem;
   }
 }
 
@@ -327,12 +319,12 @@ button.close {
 .btn.btn-raised.btn-primary,
 .btn.navigation-button,
 .btn.ethelo-likert-group-mobile {
-  background-color: #E79450 !important;
+  background-color: #e79450 !important;
   color: #1c2745;
   text-transform: lowercase;
   font-size: 1.65rem;
   border-radius: 0.625rem;
-  padding: 0.5em 2.5em;
+  padding: 0.5em 3.5em;
   letter-spacing: -0.015em;
   font-family: "Noto Sans", sans-serif;
   font-weight: 400;
@@ -341,15 +333,16 @@ button.close {
 
 .btn.btn-raised.btn-primary:hover,
 .btn.btn-raised.btn-primary:active {
-  background-color: #E79450;
+  background-color: #e79450;
 }
 
 .btn.btn-raised.btn-primary::first-letter,
 .btn.navigation-button::first-letter,
 .btn.ethelo-likert-group-mobile::first-letter {
   text-transform: uppercase !important;
-  padding-left: 3.5em !important;
 }
+
+
 .bottom-nav-buttons > .row  .btn.navigation-button:not([aria-disabled="true"]),
 .btn.ethelo-likert-group-mobile {
   border-radius: 0.625rem;
@@ -359,7 +352,6 @@ button.close {
 .bottom-nav-buttons > .row > div:first-child .btn.navigation-button {
 background: #FFF !important;
 color: #000;
-padding-left: 15px;
 }
 
   .bottom-nav-buttons .btn.navigation-button:focus,
@@ -369,22 +361,18 @@ padding-left: 15px;
 }
 
 .bottom-nav-buttons > .row .btn.navigation-button[aria-label="NEXT"] {
-  background-color: #E79450;
+  background-color: #e79450;
   color: #1c2745;
   font-weight: 700;
 }
 
-.bottom-nav-buttons > .row .btn.navigation-button * {
-  margin-left: 2.5em !important;
-}
-
 .btn.navigation-button[aria-disabled="true"] {
-  border: 2px solid #DDD;
-  background-color: #f2f2f2 !important;
-  color: rgba(148, 152, 155, 0.85) !important;
+    border: 2px solid #DDD;
+     background-color: #f2f2f2 !important;
+     color: rgba(148, 152, 155, 0.85) !important;
 }
 
-button.btn:focus,
+button.btn:focus, 
 button.btn.btn-raised.navigation-button.btn-primary:focus {
     border: inherit !important;
 }
@@ -394,20 +382,18 @@ button.btn.btn-raised.navigation-button.btn-primary:focus {
 }
 
 .container-fluid.bottom-nav-buttons {
-  display: flex;
-  flex-direction: row;
-  padding-left: 0;
+  display: flex;  
 }
 
 /*---- Collapse / Toggle styles ----*/
 
-.panel.panel-default>.panel-heading,
+.panel.panel-default>.panel-heading, 
 .panel >.panel-heading {
     background-color: transparent;
     border-bottom: 1px solid #666666;
 }
 
-.expansion-toggle.primary-accent-bg
+.expansion-toggle.primary-accent-bg 
 {
   background-color: #5489A3;
   color: #fff !important;
@@ -417,13 +403,11 @@ button.btn.btn-raised.navigation-button.btn-primary:focus {
 
 .expansion-toggle:focus {
   outline: 2px solid currentColor;
-  outline-offset: -.25em;
+  outline-offset: -.25em;  
 }
 
 .container-fluid.bottom-nav-buttons {
-  display: flex;
-  flex-direction: row;
-  padding-left: 0;
+  display: flex;  
 }
 
 /* Fix page padding */
@@ -437,13 +421,13 @@ a {
 
 /* Favorite icon */
 i.material-icons.favorite {
-  color: #FFCDA4;
+  color: #e79450;
 }
 
 /* Remove box shadows */
 .survey-page textarea.ember-text-area.form-control {
   box-shadow: none;
-  background-color: #fff;
+  background-color: #fff4eb;
 }
 
 /* Improve appearance of drop shadows */
@@ -461,31 +445,31 @@ div[class*="-column"] .panel {
 }
 
 [role="main"] .panel {
-  background: transparent;
+  background: transparent; 
   box-shadow: none;
-
+  
 }
 
 /*---- Input text and textarea ----*/
 
 .form-control, .form-group .form-control {
-  border: 2px solid #D1D1D1;
+  border: 2px solid #D1D1D1; 
   border-radius: 0.25em;
   background-image: none;
   padding: .5em;
   height: auto;
-  background-color: #fff;
 }
 
 /* fix radio button / checkbox hover effect on textboxes and textareas */
 .form-group.qradio.is-focused input[type="text"],
-.form-group.qradio.is-focused textarea,
+.form-group.qradio.is-focused textarea, 
 .form-group.qcheckbox.is-focused input[type="text"],
 .form-group.qcheckbox.is-focused textarea {
 background-image: none;
-}
+} 
 
 .survey-page .form-group {
+ background: #fff;
   padding: 2em;
 }
 
@@ -503,15 +487,7 @@ div:has(>.form-group) + div {
 
 /* Progress bar */
 .progress-bar-voting .progress-bar-voting__circle {
-  border: 3px solid #1C2745;
-  width: 69px;
-  height: 69px;
-  font-size: 24px;
-  line-height: 60px;
-  margin-top: -25px;
-  background-color: #1C2745;
-  color: #fff;
-  padding-left: 3px;
+  border: 3px solid #5489a3;
 }
 
 .progress-bar-voting__circle {
@@ -519,11 +495,11 @@ div:has(>.form-group) + div {
 }
 
 .progress-bar-voting {
-  background-color: #E79450;
+  background-color: #5489a3;
 }
 
 .progress-bar-voting .progress-bar-voting__fill {
-  background-color: #1C2745;
+  background-color: #e79450;
 }
 
 section p,
@@ -543,12 +519,12 @@ align-items: flex-start;
 
 .ethelo-likert-group li.ethelo-likert-button-container .ethelo-likert-subtext,
 .ethelo-voted-label li.ethelo-likert-button-container .ethelo-likert-subtext {
-        display: block;
+        display: block;     
         font-size: 1.2rem !important;
         line-height: 1.5 !important;
         margin-top: 0.75em;
-        text-transform: none !important;
-        visibility: visible;
+        text-transform: none !important; 
+        visibility: visible; 
         font-weight: 400;
     }
 
@@ -559,16 +535,16 @@ flex-direction: column-reverse;
 
 .ethelo-likert-subtext {
 font-weight: bold;
-text-transform: unset;
+text-transform: unset; 
 
 }
 
 .ember-view.ethelo-likert-button-container > a[role="button"] {
-    background: #F6F6F6 !important;
+    background: #F6F6F6 !important;   
     border: 2px solid #D1D1D1;
     border-radius: 50%;
     display: flex;
-    height: 2em;
+    height: 2em; 
     padding: 1em;
     width: 2em;
 }
@@ -576,7 +552,7 @@ text-transform: unset;
 .ember-view.ethelo-likert-button-container.active > .ethelo-likert-subtext {
 font-weight: bold;
 }
-.ember-view.ethelo-likert-button-container.active > a[role="button"] {
+.ember-view.ethelo-likert-button-container.active > a[role="button"] { 
     border-color: #1C2745;
     box-shadow: none;
     padding: 1em;
@@ -611,10 +587,10 @@ font-weight: normal;
     align-self: center;
   color: #000 !important;
   transform: translateX(2em);
-
+  
 }
 .modal-body .ember-view.ethelo-likert-button-container.active > a[role="button"] .ethelo-likert-text.visible-xs.visible-sm  {
- font-weight: bold;
+ font-weight: bold;    
   transform: translateX(0.33em);
 }
 
@@ -666,17 +642,13 @@ font-weight: normal;
   top: 16px;
   right: 8px;
 }
-.option-description .option-text p {
-  font-weight: 700;
-  margin-bottom: 2em;
-}
 
 /* Override comment styles */
 textarea.ember-text-area.form-control,
 .survey-page textarea.ember-text-area.form-control {
   box-shadow: none;
   padding: 1.5em;
-  background-color: #fff;
+  background-color: #F6F6F6;
  height: auto;
 }
 .list-group .row-picture img.circle {
@@ -712,8 +684,8 @@ display: none;
 .comment-item:before, .new-comment-container .form-group:before {
   content:"";
   display: inline-block;
-  background-position: center center !important;
-  background-repeat: no-repeat !important;
+       background-position: center center !important;
+   background-repeat: no-repeat !important;
   background-size: 65% !important;
   border-radius: 50%;
   padding: 2.25rem !important;
@@ -722,14 +694,14 @@ background-image: url('https://odi-uploads.s3.us-west-2.amazonaws.com/store/cc73
 }
 
 
-.comment-item-container:nth-child(3n+1) .comment-item:before ,
+.comment-item-container:nth-child(3n+1) .comment-item:before , 
 .comment-replies .comment-item-container:nth-child(3n+1) .comment-item:before  {
   background-color: #FFCDA4;
 }
 
 .comment-item-container:nth-child(3n+2) .comment-item:before ,
 .comment-replies .comment-item-container:nth-child(3n+2) .comment-item:before {
- background-color: #FFF4EB;
+ background-color: #FFF4EB; 
 }
 
 .comment-item-container:nth-child(3n+3) .comment-item:before  {
@@ -761,7 +733,7 @@ right: 1em;
 }
 
 
-.radio + .radio,
+.radio + .radio, 
 .checkbox > br + label {
   margin-top: .5em;
 }
@@ -773,7 +745,7 @@ right: 1em;
 
 
 .form-group .dropdown:not(.comment-privacy-select, .more-actions) {
-  width: 100%;
+  width: 100%; 
   min-width: 15ch;
   max-width: 30ch;
   border: 2px solid #D1D1D1;
@@ -789,7 +761,7 @@ right: 1em;
 
 .form-group .dropdown:not(.comment-privacy-select, .more-actions) .x-select {
     outline: none;
-
+  
   background: transparent;
    border: none;
   padding: 0 1em 0 0;
@@ -831,10 +803,8 @@ right: 1em;
 .container-fluid.bottom-nav-buttons * {
     float: none !important;
     width: auto !important;
-	padding-left: 0;
 }
 
 .container-fluid.bottom-nav-buttons .row.inner {
 display: flex;
-flex-direction: row;
 }


### PR DESCRIPTION

* Updates to Ethelo stylesheets for multiple engagements
* Remove prior template and adopt pattern of saving stylesheets by engagement and instance
* Reorder custom styles to top of stylesheet
* Improve responsive layout and behavior
* Update menu button color
* Hide menu button
* Add classes support for some inline custom content styles
* Demo mode hides content boxes
* Improve behavior of forms and groups in page content
