### PR TITLE
Update LA Fires sign up form and Lambda function to support radio button data

### DIFF
--- a/scripts/lambdas/MailChimp-Sign-Up-Form-Post/index.js
+++ b/scripts/lambdas/MailChimp-Sign-Up-Form-Post/index.js
@@ -1,6 +1,7 @@
 // https://github.com/cagov/engaged.ca.gov/releases/tag/MailChimp-Sign-Up-Form-Post-005
-// MailchimpForm v2.1
-// See engaged.ca.gov/site/_includes/macros/form-checkbox.njk for more documentation
+// MailchimpForm v2.2
+// See 
+// * engaged.ca.gov/site/_includes/macros/form-radio.njk for more documentation
 
 import client from "@mailchimp/mailchimp_marketing";
 

--- a/scripts/translations/translation_table_contents.py
+++ b/scripts/translations/translation_table_contents.py
@@ -249,9 +249,9 @@ translations = {
         'location': "Home",
     },
     "topic-future-topics": {
-        "en": "No",
-        "fr": "No",
-        "es": "No",
+        "en": "Future topics",
+        "fr": "Future topics",
+        "es": "Temas futuros",
         "ko": "향후 다룰 주제",
         "vi": "Chủ đề trong tương lai ",
         "tl": "Mga paksa sa hinaharap ",
@@ -262,8 +262,8 @@ translations = {
         "location": "Home"
     },
     "topic-los-angeles-fires-recovery-palisades": {
-        "en": "Yes, I was in the Palisades fire evacuation zone",
-        "fr": "Yes, I was in the Palisades fire evacuation zone",
+        "en": "Los Angeles fires recovery: Palisades",
+        "fr": "Los Angeles fires recovery: Palisades",
         "es": "Recuperación de los incendios en Los Ángeles: Palisades",
         "ko": "로스앤젤레스 산불 피해 복구: 팰리세이드(Palisades)",
         "vi": "Phục hồi sau vụ cháy ở Los Angeles: Palisades",
@@ -275,8 +275,8 @@ translations = {
         "location": "Home"
     },
     "topic-los-angeles-fires-recovery-eaton": {
-        "en": "Yes, I was in the Eaton fire evacuation zone",
-        "fr": "Yes, I was in the Eaton fire evacuation zone",
+        "en": "Los Angeles fires recovery: Eaton",
+        "fr": "Los Angeles fires recovery: Eaton",
         "es": "Recuperación de los incendios en Los Ángeles: Eaton",
         "ko": "로스앤젤레스 산불 피해 복구: 이튼(Eaton)",
         "vi": "Phục hồi sau vụ cháy ở Los Angeles: Eaton",
@@ -285,6 +285,45 @@ translations = {
         "zh-hant":"洛杉磯火災恢復：伊頓 (Eaton)",
         "fa": "احیای پس از آتشسوزی لس آنجلس :ایتون",
         "hy": "Լոս Անջելեսի հրդեհներից վերականգնում. Eaton",
+        "location": "Home"
+    },
+    "topic-los-angeles-fires-recovery-evacuation-palisades": {
+        "en": "Yes, I was in the Palisades fire evacuation zone",
+        "fr": "Yes, I was in the Palisades fire evacuation zone",
+        "es": "Yes, I was in the Palisades fire evacuation zone",
+        "ko": "Yes, I was in the Palisades fire evacuation zone",
+        "vi": "Yes, I was in the Palisades fire evacuation zone",
+        "tl": "Yes, I was in the Palisades fire evacuation zone",
+        "zh-hans": "Yes, I was in the Palisades fire evacuation zone",
+        "zh-hant": "Yes, I was in the Palisades fire evacuation zone",
+        "fa": "Yes, I was in the Palisades fire evacuation zone",
+        "hy": "Yes, I was in the Palisades fire evacuation zone",
+        "location": "Home"
+    },
+    "topic-los-angeles-fires-recovery-evacuation-eaton": {
+        "en": "Yes, I was in the Eaton fire evacuation zone",
+        "fr": "Yes, I was in the Eaton fire evacuation zone",
+        "es": "Yes, I was in the Eaton fire evacuation zone",
+        "ko": "Yes, I was in the Eaton fire evacuation zone",
+        "vi": "Yes, I was in the Eaton fire evacuation zone",
+        "tl": "Yes, I was in the Eaton fire evacuation zone",
+        "zh-hans": "Yes, I was in the Eaton fire evacuation zone",
+        "zh-hant": "Yes, I was in the Eaton fire evacuation zone",
+        "fa": "Yes, I was in the Eaton fire evacuation zone",
+        "hy": "Yes, I was in the Eaton fire evacuation zone",
+        "location": "Home"
+    },
+    "topic-los-angeles-fires-recovery-no-evacuation": {
+        "en": "No",
+        "fr": "No",
+        "es": "No",
+        "ko": "No",
+        "vi": "No",
+        "tl": "No",
+        "zh-hans": "No",
+        "zh-hant": "No",
+        "fa": "No",
+        "hy": "No",
         "location": "Home"
     },
     "valid-email-message": {

--- a/scripts/translations/translation_table_contents.py
+++ b/scripts/translations/translation_table_contents.py
@@ -183,6 +183,19 @@ translations = {
         "hy": "Տվեք մեզ ձեր էլ.հասցեն Մենք ձեզ կտեղեկացնենք, երբ թեմաները բացվեն:",
         "location": "Home"
     },
+    "join-the-conversation-form-prompt": {
+        "en": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "fr": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "es": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "ko": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "vi": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "tl": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "zh-hans": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "zh-hant": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "fa": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "hy": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "location": "Home"
+    },
     "back-to-top": {
         "en": "Back to top",
         "fr": "Haut de page",
@@ -236,9 +249,9 @@ translations = {
         'location': "Home",
     },
     "topic-future-topics": {
-        "en": "Future topics",
-        "fr": "Future topics",
-        "es": "Temas futuros",
+        "en": "No",
+        "fr": "No",
+        "es": "No",
         "ko": "향후 다룰 주제",
         "vi": "Chủ đề trong tương lai ",
         "tl": "Mga paksa sa hinaharap ",
@@ -249,8 +262,8 @@ translations = {
         "location": "Home"
     },
     "topic-los-angeles-fires-recovery-palisades": {
-        "en": "Los Angeles fires recovery: Palisades",
-        "fr": "Los Angeles fires recovery: Palisades",
+        "en": "Yes, I was in the Palisades fire evacuation zone",
+        "fr": "Yes, I was in the Palisades fire evacuation zone",
         "es": "Recuperación de los incendios en Los Ángeles: Palisades",
         "ko": "로스앤젤레스 산불 피해 복구: 팰리세이드(Palisades)",
         "vi": "Phục hồi sau vụ cháy ở Los Angeles: Palisades",
@@ -262,8 +275,8 @@ translations = {
         "location": "Home"
     },
     "topic-los-angeles-fires-recovery-eaton": {
-        "en": "Los Angeles fires recovery: Eaton",
-        "fr": "Los Angeles fires recovery: Eaton",
+        "en": "Yes, I was in the Eaton fire evacuation zone",
+        "fr": "Yes, I was in the Eaton fire evacuation zone",
         "es": "Recuperación de los incendios en Los Ángeles: Eaton",
         "ko": "로스앤젤레스 산불 피해 복구: 이튼(Eaton)",
         "vi": "Phục hồi sau vụ cháy ở Los Angeles: Eaton",

--- a/scripts/translations/translation_table_contents.py
+++ b/scripts/translations/translation_table_contents.py
@@ -274,6 +274,19 @@ translations = {
         "hy": "Լոս Անջելեսի հրդեհներից վերականգնում.Palisades",
         "location": "Home"
     },
+    "topic-los-angeles-fires-recovery-evacuation-label": {
+        "en": "Did you live or work in an evacuation zone?",
+        "fr": "Did you live or work in an evacuation zone?",
+        "es": "Did you live or work in an evacuation zone?",
+        "ko": "Did you live or work in an evacuation zone?",
+        "vi": "Did you live or work in an evacuation zone?",
+        "tl": "Did you live or work in an evacuation zone?",
+        "zh-hans": "Did you live or work in an evacuation zone?",
+        "zh-hant": "Did you live or work in an evacuation zone?",
+        "fa": "Did you live or work in an evacuation zone?",
+        "hy": "Did you live or work in an evacuation zone?",
+        "location": "Home"
+    },
     "topic-los-angeles-fires-recovery-eaton": {
         "en": "Los Angeles fires recovery: Eaton",
         "fr": "Los Angeles fires recovery: Eaton",

--- a/site/_data/i18n.js
+++ b/site/_data/i18n.js
@@ -208,6 +208,19 @@ const translations = {
         "hy": "Տրամադրեք մեզ Ձեր էլեկտրոնային հասցեն։ Մենք Ձեզ կտեղեկացնենք, թե երբ է սկսվելու ներգրավվածության գործընթացը։",
         "location": "Home"
     },
+    "join-the-conversation-form-prompt": {
+        "en": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "fr": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "es": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "ko": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "vi": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "tl": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "zh-hans": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "zh-hant": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "fa": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "hy": "Deliberations for LA fires recovery start soon. Give us your email if you're interested in participating.",
+        "location": "Home"
+    },
     "back-to-top": {
         "en": "Back to top",
         "fr": "Haut de page",
@@ -274,8 +287,8 @@ const translations = {
         "location": "Home"
     },
     "topic-los-angeles-fires-recovery-palisades": {
-        "en": "Los Angeles fires recovery: Palisades",
-        "fr": "Los Angeles fires recovery: Palisades",
+        "en": "Yes, I was in the Palisades fire evacuation zone",
+        "fr": "Yes, I was in the Palisades fire evacuation zone",
         "es": "Recuperación de los incendios en Los Ángeles: Palisades",
         "ko": "로스앤젤레스 산불 피해 복구: 팰리세이드(Palisades)",
         "vi": "Phục hồi sau vụ cháy ở Los Angeles: Palisades",
@@ -287,8 +300,8 @@ const translations = {
         "location": "Home"
     },
     "topic-los-angeles-fires-recovery-eaton": {
-        "en": "Los Angeles fires recovery: Eaton",
-        "fr": "Los Angeles fires recovery: Eaton",
+        "en": "Yes, I was in the Eaton fire evacuation zone",
+        "fr": "Yes, I was in the Eaton fire evacuation zone",
         "es": "Recuperación de los incendios en Los Ángeles: Eaton",
         "ko": "로스앤젤레스 산불 피해 복구: 이튼(Eaton)",
         "vi": "Phục hồi sau vụ cháy ở Los Angeles: Eaton",

--- a/site/_data/i18n.js
+++ b/site/_data/i18n.js
@@ -287,8 +287,8 @@ const translations = {
         "location": "Home"
     },
     "topic-los-angeles-fires-recovery-palisades": {
-        "en": "Yes, I was in the Palisades fire evacuation zone",
-        "fr": "Yes, I was in the Palisades fire evacuation zone",
+        "en": "Los Angeles fires recovery: Palisades",
+        "fr": "Los Angeles fires recovery: Palisades",
         "es": "Recuperación de los incendios en Los Ángeles: Palisades",
         "ko": "로스앤젤레스 산불 피해 복구: 팰리세이드(Palisades)",
         "vi": "Phục hồi sau vụ cháy ở Los Angeles: Palisades",
@@ -300,8 +300,8 @@ const translations = {
         "location": "Home"
     },
     "topic-los-angeles-fires-recovery-eaton": {
-        "en": "Yes, I was in the Eaton fire evacuation zone",
-        "fr": "Yes, I was in the Eaton fire evacuation zone",
+        "en": "Los Angeles fires recovery: Eaton",
+        "fr": "Los Angeles fires recovery: Eaton",
         "es": "Recuperación de los incendios en Los Ángeles: Eaton",
         "ko": "로스앤젤레스 산불 피해 복구: 이튼(Eaton)",
         "vi": "Phục hồi sau vụ cháy ở Los Angeles: Eaton",
@@ -310,6 +310,45 @@ const translations = {
         "zh-hant":"洛杉磯火災恢復：伊頓 (Eaton)",
         "fa": "احیای پس از آتشسوزی لس آنجلس :ایتون",
         "hy": "Լոս Անջելեսի հրդեհներից վերականգնում. Eaton",
+        "location": "Home"
+    },
+    "topic-los-angeles-fires-recovery-evacuation-palisades": {
+        "en": "Yes, I was in the Palisades fire evacuation zone",
+        "fr": "Yes, I was in the Palisades fire evacuation zone",
+        "es": "Yes, I was in the Palisades fire evacuation zone",
+        "ko": "Yes, I was in the Palisades fire evacuation zone",
+        "vi": "Yes, I was in the Palisades fire evacuation zone",
+        "tl": "Yes, I was in the Palisades fire evacuation zone",
+        "zh-hans": "Yes, I was in the Palisades fire evacuation zone",
+        "zh-hant": "Yes, I was in the Palisades fire evacuation zone",
+        "fa": "Yes, I was in the Palisades fire evacuation zone",
+        "hy": "Yes, I was in the Palisades fire evacuation zone",
+        "location": "Home"
+    },
+    "topic-los-angeles-fires-recovery-evacuation-eaton": {
+        "en": "Yes, I was in the Eaton fire evacuation zone",
+        "fr": "Yes, I was in the Eaton fire evacuation zone",
+        "es": "Yes, I was in the Eaton fire evacuation zone",
+        "ko": "Yes, I was in the Eaton fire evacuation zone",
+        "vi": "Yes, I was in the Eaton fire evacuation zone",
+        "tl": "Yes, I was in the Eaton fire evacuation zone",
+        "zh-hans": "Yes, I was in the Eaton fire evacuation zone",
+        "zh-hant": "Yes, I was in the Eaton fire evacuation zone",
+        "fa": "Yes, I was in the Eaton fire evacuation zone",
+        "hy": "Yes, I was in the Eaton fire evacuation zone",
+        "location": "Home"
+    },
+    "topic-los-angeles-fires-recovery-no-evacuation": {
+        "en": "No",
+        "fr": "No",
+        "es": "No",
+        "ko": "No",
+        "vi": "No",
+        "tl": "No",
+        "zh-hans": "No",
+        "zh-hant": "No",
+        "fa": "No",
+        "hy": "No",
         "location": "Home"
     },
     "valid-email-message": {

--- a/site/_data/i18n.js
+++ b/site/_data/i18n.js
@@ -286,6 +286,19 @@ const translations = {
         "hy": "Ապագա թեմաներ",
         "location": "Home"
     },
+    "topic-los-angeles-fires-recovery-evacuation-label": {
+        "en": "Did you live or work in an evacuation zone?",
+        "fr": "Did you live or work in an evacuation zone?",
+        "es": "Did you live or work in an evacuation zone?",
+        "ko": "Did you live or work in an evacuation zone?",
+        "vi": "Did you live or work in an evacuation zone?",
+        "tl": "Did you live or work in an evacuation zone?",
+        "zh-hans": "Did you live or work in an evacuation zone?",
+        "zh-hant": "Did you live or work in an evacuation zone?",
+        "fa": "Did you live or work in an evacuation zone?",
+        "hy": "Did you live or work in an evacuation zone?",
+        "location": "Home"
+    },
     "topic-los-angeles-fires-recovery-palisades": {
         "en": "Los Angeles fires recovery: Palisades",
         "fr": "Los Angeles fires recovery: Palisades",

--- a/site/_includes/form-lafires.njk
+++ b/site/_includes/form-lafires.njk
@@ -1,0 +1,80 @@
+{# Import macros. #}
+{% import "macros/form-lafires-radio.njk" as radio %}
+{% import "macros/form-action.njk" as action %}
+{% import "macros/form-submit.njk" as submit %}
+
+{# Begin HTML. #}
+<h2>{{ 'join-the-conversation' | i18n }}</h2>
+{% block formHeading %}
+  <p>{{ 'join-the-conversation-form-label' | i18n }}</p>
+  <p>{{ 'join-the-conversation-form-prompt' | i18n }}</p>
+{% endblock formHeading %}
+
+<engca-join-convo-form>
+
+  {% block formAction %}
+    {{ action.data("61200a6dda", "0003e1e3f0") }}
+  {% endblock formAction %}
+
+  <engca-form-field>
+    <label class="form-control-label" for="mce-EMAIL">
+      <span aria-hidden="true">*</span>
+      <span class="sr-only">{{ 'required-label' | i18n }}:</span>
+      {% block formEmail %}
+        {{ 'email-label' | i18n }}
+      {% endblock formEmail %}
+    </label>
+
+    <p>
+      <input type="email" class="form-control" id="mce-EMAIL" name="EMAIL" aria-required="true">
+    </p>
+
+    <fieldset>
+      <ul class="form-radio-list">
+        <li>
+          {{ radio.merge_field_data('topic-los-angeles-fires-recovery-eaton' | i18n, "Eaton", "Yes, I was in the Eaton fire evacuation zone", "EVACZONE") }}
+        </li>
+        <li>
+          {{ radio.merge_field_data('topic-los-angeles-fires-recovery-palisades' | i18n, "Palisades", "Yes, I was in the Palisades fire evacuation zone", "EVACZONE" ) }}
+        </li>
+        <li>
+          {{ radio.interest_data('topic-future-topics' | i18n, "4d15bd19e5") }}
+        </li>
+      </ul>
+    </fieldset>
+
+    <engca-form-error id="emailError" hidden>
+      <strong>{{ 'valid-email-message' | i18n }}</strong>
+      {{ 'valid-email-message-2' | i18n }}
+    </engca-form-error>
+    <engca-form-error id="apiError" hidden>
+      <strong>{{ 'form-problem-message' | i18n }}</strong>
+      {{ 'form-problem-message-2' | i18n }}
+    </engca-form-error>
+  </engca-form-field>
+
+  <engca-form-field>
+    {% block formContent %}
+
+    {% endblock formContent %}
+
+  </engca-form-field>
+
+  {{ submit.data('form-submit-button' | i18n) }}
+
+  </form>
+
+  <engca-form-success aria-live="polite"></engca-form-success>
+  <template id="form-success-msg">
+    <p>
+      <strong>{{ 'form-success-message' | i18n }}</strong>
+    </p>
+    <img width="75" height="75" src="/public/images/check-circle.svg" aria-hidden="true" alt="" />
+    <p>{{ 'form-success-message-2' | i18n }}</p>
+  </template>
+</engca-join-convo-form>
+<p>
+  {{ 'form-privacy-message' | i18n | safe }} 
+  {{ 'form-privacy-message-1' | i18n | safe }}
+  {{ 'form-privacy-message-2' | i18n | safe }}
+</p>

--- a/site/_includes/form-lafires.njk
+++ b/site/_includes/form-lafires.njk
@@ -6,7 +6,6 @@
 {# Begin HTML. #}
 <h2>{{ 'join-the-conversation' | i18n }}</h2>
 {% block formHeading %}
-  <p>{{ 'join-the-conversation-form-label' | i18n }}</p>
   <p>{{ 'join-the-conversation-form-prompt' | i18n }}</p>
 {% endblock formHeading %}
 

--- a/site/_includes/form-lafires.njk
+++ b/site/_includes/form-lafires.njk
@@ -28,7 +28,12 @@
       <input type="email" class="form-control" id="mce-EMAIL" name="EMAIL" aria-required="true">
     </p>
 
-    <fieldset>
+    <fieldset name="radio-group-label">
+      <label class="form-control-label" for="radio-group-label">
+        <span aria-hidden="true">*</span>
+        <span class="sr-only">{{ 'required-label' | i18n }}:</span>
+          {{ 'topic-los-angeles-fires-recovery-evacuation-label' | i18n }}
+      </label>
       <ul class="form-radio-list">
         <li>
           {{ radio.merge_field_data('topic-los-angeles-fires-recovery-evacuation-eaton' | i18n, "Eaton", "Yes, I was in the Eaton fire evacuation zone", "EVACZONE") }}

--- a/site/_includes/form-lafires.njk
+++ b/site/_includes/form-lafires.njk
@@ -32,13 +32,13 @@
     <fieldset>
       <ul class="form-radio-list">
         <li>
-          {{ radio.merge_field_data('topic-los-angeles-fires-recovery-eaton' | i18n, "Eaton", "Yes, I was in the Eaton fire evacuation zone", "EVACZONE") }}
+          {{ radio.merge_field_data('topic-los-angeles-fires-recovery-evacuation-eaton' | i18n, "Eaton", "Yes, I was in the Eaton fire evacuation zone", "EVACZONE") }}
         </li>
         <li>
-          {{ radio.merge_field_data('topic-los-angeles-fires-recovery-palisades' | i18n, "Palisades", "Yes, I was in the Palisades fire evacuation zone", "EVACZONE" ) }}
+          {{ radio.merge_field_data('topic-los-angeles-fires-recovery-evacuation-palisades' | i18n, "Palisades", "Yes, I was in the Palisades fire evacuation zone", "EVACZONE" ) }}
         </li>
         <li>
-          {{ radio.interest_data('topic-future-topics' | i18n, "4d15bd19e5") }}
+          {{ radio.merge_field_data('topic-los-angeles-fires-recovery-no-evacuation' | i18n, "No", "No", "EVACZONE" ) }}
         </li>
       </ul>
     </fieldset>

--- a/site/_includes/macros/form-lafires-radio.njk
+++ b/site/_includes/macros/form-lafires-radio.njk
@@ -1,0 +1,50 @@
+{#
+Note: audienceId is referred to as list_id in the mailchimp API docs
+
+1. Get the Audience Id from the MailChimip UI
+
+    Audience Ids
+        Engaged Califonia:  61200a6dda
+        Government Efficiencies: 417d16b2c0
+
+2. Get the categories.list_id
+    curl -i -H POST --url 'https://us2.api.mailchimp.com/3.0/lists/[audienceId]/interest-categories/' --header "Authorization: Bearer [TOKEN]"
+
+    Interest category Ids
+        Engaged Califonia:  2a44a8fff7 (For Future topics)
+        Government Efficiencies: 9cd68bb129
+
+3. Get the interest ids
+    curl -i -H POST --url 'https://us2.api.mailchimp.com/3.0/lists/[audienceId]/interest-categories/[listid]/interests' --header "Authorization: Bearer [TOKEN]"
+
+    Interest Ids
+        0f531f3ce0 - I certify I am a current State of California employee
+        ~ (Historical data) 1552878c1b - Los Angeles fires recovery: Eaton ~
+        ~ (Historical data) 40c0f946cd - Los Angeles fires recovery: Palisades ~
+        4d15bd19e5 - "Future topics",
+
+API docs for interests https://mailchimp.com/developer/marketing/api/interests/
+
+4. Get ids for merge_fields (IN progress)
+
+#}
+
+{#
+i18nkey - (String) The key of the text string as definited in i18n.js
+interest_id - (String) See comment above
+attributes - (String) Add a space separated list of attributes such as "checked required"
+#}
+
+{% macro interest_data(i8nkey, interest_id, attributes) %}
+    <input type="radio" class="form-radio-input" id="{{ interest_id }}" name="lafires-radio-group-{{ interest_id }}" value="{{ i8nkey }}" {{ attributes }}>
+    <label class="form-control-label form-radio-label" for="{{ interest_id }}">
+        {{ i8nkey }}
+    </label>
+{% endmacro %}
+
+{% macro merge_field_data(i8nkey, value, value_label, radio_name, attributes) %}
+    <input type="radio" class="form-radio-input" id="{{ radio_name }}-{{ value }}" name="{{ radio_name }}" value="{{ i8nkey }}" {{ attributes }}>
+    <label class="form-control-label form-radio-label" for="{{ radio_name }}-{{ value }}">
+        {{ i8nkey }}
+    </label>
+{% endmacro %}

--- a/site/_includes/mmmd-lafires.njk
+++ b/site/_includes/mmmd-lafires.njk
@@ -76,7 +76,7 @@
   <div class="container form-flex">
     <img src="/public/images/bubble-cluster-1.svg" class="signup-cluster-1" aria-hidden="true" alt=""/>
     <img src="/public/images/bubble-cluster-2.svg" class="signup-cluster-2" aria-hidden="true" alt=""/>
-    {% include "form.njk" %}
+    {% include "form-lafires.njk" %}
   </div>
 </section>
 

--- a/src/css/form.css
+++ b/src/css/form.css
@@ -111,13 +111,37 @@ engca-form-success > p {
   border-radius: 0em;
 }
 
+.form-radio-input[type="radio"] {
+  border-radius: 0em;
+}
+
 .form-check-input {
   background-color: transparent;
   border-width: 2px;
   margin-right: 21px;
 }
 
+.form-radio-input {
+  background-color: transparent;
+  border-width: 2px;
+  margin: 0 8px;
+  padding: 0;
+  border: 0px;
+  width: 1rem;
+  height: 1rem;
+  margin: 12px 8px 0 8px;
+  padding: 0;
+}
+
 .form-checkbox-label {
+  color: var(--Dark-Palette-Off-White, #fff4eb);
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 39px; /* 216.667% */
+}
+
+.form-radio-label {
   color: var(--Dark-Palette-Off-White, #fff4eb);
   font-size: 18px;
   font-style: normal;
@@ -140,6 +164,19 @@ ul.form-checkbox-list li {
   list-style: none;
   padding: 0;
   display: flex;
+}
+
+ul.form-radio-list li {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  margin: 0;
+  padding: 0;
+}
+
+ul.form-radio-list {
+  margin: 0;
+  padding: 0;
 }
 
 .form-title {


### PR DESCRIPTION
* Support 3 new radio buttons in template for evacuation zone for LA Fires sign up form
* Support custom form for LA Fires on LA Fires recovery page
* Add placeholder language strings for new form
* Update Lambda function and ensure it supports radio button data, email only data. (Interests and Radio button data are not the same)
  * Notes 
     - This should be able to merge with [PR #56 ](https://github.com/cagov/engaged.ca.gov/pull/56), but recommend testing
     - There is an additional support in case the "No" value should instead set user Interest to "Future topics" but this seems like Mailchimp anti-pattern for subscriber experience. We can remove this when confirmed, but I did hear conflicting messages about this earlier today. 
* Also reviewed the Mailchimp user journey and we can enable that as soon as this goes live, after disabling the current user journey.