### PR TITLE
Build scripts update

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -56,26 +56,18 @@ jobs:
           echo 'User-agent: *' > _dist/robots.txt
           echo 'Disallow: /' >> _dist/robots.txt
 
-      - name: Deploy site to S3
-        uses: jakejarvis/s3-sync-action@v0.5.1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@master
         with:
-          args: --follow-symlinks --delete
-        env:
-          AWS_S3_BUCKET: "pr.engaged.ca.gov"
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: "us-west-1"
-          SOURCE_DIR: ./_dist
-          DEST_DIR: pr/${URLSAFE_BRANCH_NAME}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-1
+
+      - name: Deploy site to S3
+        run: aws s3 sync --follow-symlinks --delete ./_dist s3://pr.engaged.ca.gov/pr/${URLSAFE_BRANCH_NAME}
 
       - name: Invalidate Cloudfront cache
-        uses: chetan/invalidate-cloudfront-action@v2
-        env:
-          DISTRIBUTION: "EJBCVN0CVEA2Z"
-          PATHS: "/*"
-          AWS_REGION: "us-west-1"
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id EJBCVN0CVEA2Z --paths "/*"
 
       - name: Post URL to PR
         uses: mshick/add-pr-comment@v2.8.2

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -33,22 +33,16 @@ jobs:
           echo 'User-agent: *' > _dist/robots.txt
           echo 'Allow: /' >> _dist/robots.txt
 
-      - name: Deploy site to S3
-        uses: jakejarvis/s3-sync-action@v0.5.1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@master
         with:
-          args: --follow-symlinks --delete
-        env:
-          AWS_S3_BUCKET: "engaged.ca.gov"
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: "us-west-1"
-          SOURCE_DIR: ./_dist
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-1
+
+      - name: Deploy site to S3
+        run: aws s3 sync --follow-symlinks --delete ./_dist s3://engaged.ca.gov
 
       - name: Invalidate Cloudfront cache
-        uses: chetan/invalidate-cloudfront-action@v2
-        env:
-          DISTRIBUTION: "E17BKU1V60O1VJ"
-          PATHS: "/*"
-          AWS_REGION: "us-west-1"
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id  E17BKU1V60O1VJ --paths "/*"
+


### PR DESCRIPTION
Reduce reliance on 3rd party plugins for simple AWS tasks, for greater resiliency, and reduced code size:

* Eliminates use of jakejarvis/s3-sync-action and chetan/invalidate-cloudfront-action, and instead runs the underlying aws cli commands directly, a feature supported by github.

* Simplifies the build scripts (19 -> 10 lines), eliminating redundancy in credentials and region params.
