### PR TITLE
Change state of site to reflect ending deliberations for lafires.

### DIFF
--- a/site/_includes/mmmd-homepage.njk
+++ b/site/_includes/mmmd-homepage.njk
@@ -23,14 +23,14 @@
     <img src="/public/images/about-bubbles.svg" aria-hidden="true" class="desktop-only" alt="{{ 'home-alt-header-about' | i18n }}" />
   </div>
 </section>
-<section id="our-first-engagement" class="action-hero">
+{# <section id="our-first-engagement" class="action-hero">
   <div class="container first-eng-content">
     {{ modules.deliberations_are_happening.content | safe }}
     <a href="{{ "/lafires-recovery/" | locale_url }}" data-appearance="button" data-theme="orange">
       {{ modules.deliberations_are_happening.buttonText }}
     </a>
   </div>
-</section>
+</section> #}
 <section id="how-it-works" class="action-hero">
   <div class="container">
     <h2>{{ 'how-it-works' | i18n }}</h2>

--- a/site/_includes/mmmd-lafires.njk
+++ b/site/_includes/mmmd-lafires.njk
@@ -4,7 +4,7 @@
 <section id="los-angeles-fires-recovery" class="hero">
   <div class="container banner-flex">
     <engca-banner-content>
-      <p class="status-pill">{{ modules.hero_2.statusPlanningTextV2 }}</p>
+      <p class="status-pill">{{ modules.hero_2.statusDeliberationsClosedText }}</p>
       <h1>{{ title }}</h1>
       {{ modules.hero_2.content | safe }}
       {# <p>
@@ -59,8 +59,8 @@
           {{ phase(modules.phase2, "complete", "complete") }}
           {{ phase(modules.phase3, "complete", "complete") }}
           {{ phase(modules.phase4, "complete", "complete") }}
-          {{ phase(modules.phase5, "current", "pending") }}
-          {{ phase(modules.phase6, "pending", "none") }}
+          {{ phase(modules.phase5, "complete", "pending") }}
+          {{ phase(modules.phase6, "current", "none") }}
         </div>
       </div>
       <div class="col-lg-4">

--- a/site/en/lafires-recovery.mmmd
+++ b/site/en/lafires-recovery.mmmd
@@ -31,6 +31,7 @@ statusReviewText: Agenda setting outcomes are being reviewed
 statusPlanningText: We are planning deliberations
 buttonText: See what we found in agenda setting
 statusPlanningTextV2: Deliberations are happening now
+statusDeliberationsClosedText: Community deliberations are closed
 buttonTextV2: Sign up now
 ----
 

--- a/site/es/lafires-recovery.mmmd
+++ b/site/es/lafires-recovery.mmmd
@@ -28,6 +28,7 @@ statusReviewText: Se están revisando los resultados de la agenda
 statusPlanningText: Se están planificando deliberaciones
 buttonText: Vea lo que encontramos respecto al establecimiento de la agenda
 statusPlanningTextV2: Deliberaciones están sucediendo ahora
+statusDeliberationsClosedText: Las deliberaciones de la comunidad han finalizado
 buttonTextV2: Regístrese ahora
 ----
 

--- a/site/es/lafires-recovery.mmmd
+++ b/site/es/lafires-recovery.mmmd
@@ -28,7 +28,7 @@ statusReviewText: Se están revisando los resultados de la agenda
 statusPlanningText: Se están planificando deliberaciones
 buttonText: Vea lo que encontramos respecto al establecimiento de la agenda
 statusPlanningTextV2: Deliberaciones están sucediendo ahora
-statusDeliberationsClosedText: Las deliberaciones de la comunidad han finalizado
+statusDeliberationsClosedText: Las deliberaciones de la comunidad están cerradas
 buttonTextV2: Regístrese ahora
 ----
 

--- a/site/fa/lafires-recovery.mmmd
+++ b/site/fa/lafires-recovery.mmmd
@@ -28,7 +28,7 @@ statusReviewText: نتایج تنظیم دستور کار در حال بررسی
 statusPlanningText: مذاکرات در حال برنامه ریزی است
 buttonText: ببینید در تنظیم دستور کار چه چیزی پیدا کردیم
 statusPlanningTextV2: بحث‎‌ها در حال انجام هستند
-statusDeliberationsClosedText: بحث های جامعه به پایان رسیده است
+statusDeliberationsClosedText: جلسات مشورتی جامعه تعطیل است
 buttonTextV2: ثبت نام کنید
 ----
 

--- a/site/fa/lafires-recovery.mmmd
+++ b/site/fa/lafires-recovery.mmmd
@@ -28,6 +28,7 @@ statusReviewText: نتایج تنظیم دستور کار در حال بررسی
 statusPlanningText: مذاکرات در حال برنامه ریزی است
 buttonText: ببینید در تنظیم دستور کار چه چیزی پیدا کردیم
 statusPlanningTextV2: بحث‎‌ها در حال انجام هستند
+statusDeliberationsClosedText: بحث های جامعه به پایان رسیده است
 buttonTextV2: ثبت نام کنید
 ----
 

--- a/site/hy/lafires-recovery.mmmd
+++ b/site/hy/lafires-recovery.mmmd
@@ -28,6 +28,7 @@ statusReviewText: Օրակարգային կարգավորումների արդյ
 statusPlanningText: Ներկայումս նախատեսվում են քննարկումներ
 buttonText: Տեսեք, թե ինչ հայտնաբերեցինք օրակարգի ձևավորման մեջ
 statusPlanningTextV2: Խնդրագիտություններ են առաջանում
+statusDeliberationsClosedText: Խնդրագիտությունները ավարտվել են
 buttonTextV2: Գրանցվեք՝ տեղեկացված մնալու համար
 ----
 

--- a/site/hy/lafires-recovery.mmmd
+++ b/site/hy/lafires-recovery.mmmd
@@ -28,7 +28,7 @@ statusReviewText: Օրակարգային կարգավորումների արդյ
 statusPlanningText: Ներկայումս նախատեսվում են քննարկումներ
 buttonText: Տեսեք, թե ինչ հայտնաբերեցինք օրակարգի ձևավորման մեջ
 statusPlanningTextV2: Խնդրագիտություններ են առաջանում
-statusDeliberationsClosedText: Խնդրագիտությունները ավարտվել են
+statusDeliberationsClosedText: Համայնքային քննարկումները փակ են
 buttonTextV2: Գրանցվեք՝ տեղեկացված մնալու համար
 ----
 

--- a/site/ko/lafires-recovery.mmmd
+++ b/site/ko/lafires-recovery.mmmd
@@ -28,6 +28,7 @@ statusReviewText: 의제 설정 결과를 검토 중입니다
 statusPlanningText: 심의를 계획 중입니다
 buttonText: 의제 설정에서 찾은 내용을 확인하십시오
 statusPlanningTextV2: 심의가 진행 중입니다
+statusDeliberationsClosedText: 커뮤니티 심의가 종료되었습니다
 buttonTextV2: 등록하십시오
 ----
 

--- a/site/ko/lafires-recovery.mmmd
+++ b/site/ko/lafires-recovery.mmmd
@@ -28,7 +28,7 @@ statusReviewText: 의제 설정 결과를 검토 중입니다
 statusPlanningText: 심의를 계획 중입니다
 buttonText: 의제 설정에서 찾은 내용을 확인하십시오
 statusPlanningTextV2: 심의가 진행 중입니다
-statusDeliberationsClosedText: 커뮤니티 심의가 종료되었습니다
+statusDeliberationsClosedText: 커뮤니티의 심의가 종료되었습니다
 buttonTextV2: 등록하십시오
 ----
 

--- a/site/tl/lafires-recovery.mmmd
+++ b/site/tl/lafires-recovery.mmmd
@@ -28,7 +28,7 @@ statusReviewText: Ang mga resulta ng pagtatakda ng agenda ay sinusuri
 statusPlanningText: Pinaplano ang mga deliberasyon
 buttonText: Tingnan ang napag-alaman namin sa pagtatakda ng agenda
 statusPlanningTextV2: Ang mga deliberasyon ay nangyayari na
-statusDeliberationsClosedText: Ang mga deliberasyon ng komunidad ay natapos na
+statusDeliberationsClosedText: Tapos na ang mga deliberasyon ng komunidad
 buttonTextV2: Mag-sign up ngayon
 ----
 

--- a/site/tl/lafires-recovery.mmmd
+++ b/site/tl/lafires-recovery.mmmd
@@ -28,6 +28,7 @@ statusReviewText: Ang mga resulta ng pagtatakda ng agenda ay sinusuri
 statusPlanningText: Pinaplano ang mga deliberasyon
 buttonText: Tingnan ang napag-alaman namin sa pagtatakda ng agenda
 statusPlanningTextV2: Ang mga deliberasyon ay nangyayari na
+statusDeliberationsClosedText: Ang mga deliberasyon ng komunidad ay natapos na
 buttonTextV2: Mag-sign up ngayon
 ----
 

--- a/site/vi/lafires-recovery.mmmd
+++ b/site/vi/lafires-recovery.mmmd
@@ -28,6 +28,7 @@ statusReviewText: Đánh giá kết quả xây dựng chương trình nghị s�
 statusPlanningText: Lên kế hoạch các cuộc thảo luận
 buttonText: Xem những phát hiện của chúng tôi trong việc thiết lập chương trình nghị sự
 statusPlanningTextV2: Các cuộc thảo luận đang diễn ra
+statusDeliberationsClosedText: Các cuộc thảo luận cộng đồng đã kết thúc
 buttonTextV2: Đăng ký ngay
 ----
 

--- a/site/vi/lafires-recovery.mmmd
+++ b/site/vi/lafires-recovery.mmmd
@@ -28,7 +28,7 @@ statusReviewText: Đánh giá kết quả xây dựng chương trình nghị s�
 statusPlanningText: Lên kế hoạch các cuộc thảo luận
 buttonText: Xem những phát hiện của chúng tôi trong việc thiết lập chương trình nghị sự
 statusPlanningTextV2: Các cuộc thảo luận đang diễn ra
-statusDeliberationsClosedText: Các cuộc thảo luận cộng đồng đã kết thúc
+statusDeliberationsClosedText: Các cuộc thảo luận của cộng đồng đã kết thúc
 buttonTextV2: Đăng ký ngay
 ----
 

--- a/site/zh-hans/lafires-recovery.mmmd
+++ b/site/zh-hans/lafires-recovery.mmmd
@@ -28,7 +28,7 @@ statusReviewText: 正在审查议程设置结果
 statusPlanningText: 正在计划审议
 buttonText: 看看我们在工作计划中发现了什么
 statusPlanningTextV2: 审议正在进行中
-statusDeliberationsClosedText: 社区审议已结束
+statusDeliberationsClosedText: 社区协商已经结束
 buttonTextV2: 注册以随时了解情况
 ----
 

--- a/site/zh-hans/lafires-recovery.mmmd
+++ b/site/zh-hans/lafires-recovery.mmmd
@@ -28,6 +28,7 @@ statusReviewText: 正在审查议程设置结果
 statusPlanningText: 正在计划审议
 buttonText: 看看我们在工作计划中发现了什么
 statusPlanningTextV2: 审议正在进行中
+statusDeliberationsClosedText: 社区审议已结束
 buttonTextV2: 注册以随时了解情况
 ----
 

--- a/site/zh-hant/lafires-recovery.mmmd
+++ b/site/zh-hant/lafires-recovery.mmmd
@@ -28,7 +28,7 @@ statusReviewText: 正在審查議程設定結果
 statusPlanningText: 正在計劃審議
 buttonText: 看看我們在工作計畫中發現了什麼
 statusPlanningTextV2: 協商正在進行中
-statusDeliberationsClosedText: 社區協商已結束
+statusDeliberationsClosedText: 社區商議已經結束
 buttonTextV2: 註冊以隨時瞭解情況
 ----
 

--- a/site/zh-hant/lafires-recovery.mmmd
+++ b/site/zh-hant/lafires-recovery.mmmd
@@ -28,6 +28,7 @@ statusReviewText: 正在審查議程設定結果
 statusPlanningText: 正在計劃審議
 buttonText: 看看我們在工作計畫中發現了什麼
 statusPlanningTextV2: 協商正在進行中
+statusDeliberationsClosedText: 社區協商已結束
 buttonTextV2: 註冊以隨時瞭解情況
 ----
 


### PR DESCRIPTION
* Remove “deliberations are happening” section of homepage
* Update status pill to say “Community deliberations are closed”
* Update timeline to be on “reporting”