### PR TITLE
Security fix

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -49,7 +49,8 @@ jobs:
       - name: Build site
         run: |
           mkdir _dist
-          npm install
+          # using npm ci instead of npm install to reduce threat of installing newer packages than intended
+          npm ci
           DOMAIN=${URLSAFE_BRANCH_NAME}.pr.engaged.ca.gov npm run build
 
       - name: Write robots.txt

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Build site
         run: |
           mkdir _dist
-          npm install
+          # using npm ci instead of npm install to reduce threat of installing newer packages than intended
+          npm ci
           npm run build
 
       # Modify when site goes live.


### PR DESCRIPTION
Modified deploy scripts to use `npm ci` instead of `npm install`.

This is to prevent accidental installation of a package version later than the one currently used in package-lock.json, which is an avenue thru which compromised packages can be installed. 