### PR TITLE
Set least-privilege GITHUB_TOKEN permissions on deploy workflows

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -16,7 +16,6 @@ jobs:
     if: "!contains(github.head_ref, 'dependabot')"
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
       pull-requests: write
     steps:

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -9,6 +9,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege GITHUB_TOKEN: only checkout reads repo contents.
+# AWS auth uses static access keys (not OIDC), so no id-token is needed.
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Resolves CodeQL code-scanning alert [#1](https://github.com/cagov/engaged.ca.gov/security/code-scanning/1) (`actions/missing-workflow-permissions`, medium). `deploy_prod.yml` declared no `permissions:` block, so its `GITHUB_TOKEN` inherited the broad repo/org default scopes.

## Changes

**`deploy_prod.yml`** — add an explicit minimal block:
```yaml
permissions:
  contents: read
```
Only `actions/checkout` uses the token; AWS auth uses static access keys (not OIDC), and nothing writes back to the repo — so `contents: read` is sufficient and matches CodeQL's suggested minimum.

**`deploy_preview.yml`** — remove the unused `id-token: write`:
- `id-token: write` is only needed for OIDC AWS role assumption, which this workflow doesn't use (it uses static `AWS_*` secrets).
- Retains `contents: read` (checkout) and `pull-requests: write` (the `add-pr-comment` step).

Both workflows now declare exactly the scopes they use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)