### PR TITLE
Fix main-nav a11y violation and make Playwright target the right server

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,21 @@
+import { defineConfig } from "@playwright/test";
+
+// Dedicated port so the suite never picks up an unrelated dev server. 8080 is a
+// common default and was previously being tested by accident.
+const PORT = process.env.PORT || 8288;
+
+export default defineConfig({
+  testDir: "./test",
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+  },
+  // Build and serve _dist ourselves so `npm run test` is self-contained.
+  // reuseExistingServer stays false: if the port is busy we want a loud failure
+  // rather than silently testing whatever is already listening.
+  webServer: {
+    command: `npm run build && npx --yes http-server _dist/ -p ${PORT} --silent`,
+    url: `http://localhost:${PORT}/`,
+    reuseExistingServer: false,
+    timeout: 120 * 1000,
+  },
+});

--- a/site/_includes/layout.njk
+++ b/site/_includes/layout.njk
@@ -170,16 +170,16 @@
         <!-- navigation types -->
         <nav id="navigation" class="main-navigation dropdown" aria-label="Main navigation">
           <ul id="nav_list" class="top-level-nav">
-            <li class="nav-item {% if active_page == 'about' %}active{% endif %}" role="presentation">
+            <li class="nav-item {% if active_page == 'about' %}active{% endif %}">
               <a class="first-level-link" href="{{ '/about' | localizedPath(locale) }}">{{ 'about-the-program' | i18n }}</a>
             </li>
-            <li class="nav-item {% if active_page == 'lafires-recovery' %}active{% endif %}" role="presentation">
+            <li class="nav-item {% if active_page == 'lafires-recovery' %}active{% endif %}">
               <a class="first-level-link" href="{{ '/lafires-recovery' | localizedPath(locale) }}">{{ 'los-angeles-fires-recovery' | i18n }}</a>
             </li>
-            <li class="nav-item {% if active_page == 'stateemployees' %}active{% endif %}" role="presentation">
+            <li class="nav-item {% if active_page == 'stateemployees' %}active{% endif %}">
               <a class="first-level-link" href="{{ '/stateemployees' | localizedPath(locale) }}">{{ 'state-employees' | i18n }}</a>
             </li>
-            <li class="nav-item {% if active_page == 'ai-impact' %}active{% endif %}" role="presentation">
+            <li class="nav-item {% if active_page == 'ai-impact' %}active{% endif %}">
               <a class="first-level-link" href="{{ '/ai-impact' | localizedPath(locale) }}">{{ 'impact-of-AI-on-work' | i18n }}</a>
             </li>
             {# use this for eventual pull-down when number of links >=4 #}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,13 +1,12 @@
-import { test, expect } from "@playwright/test";
-import { injectAxe, checkA11y } from "axe-playwright";
-
-const testLocation = "http://localhost:8080";
+import { test } from "@playwright/test";
+import { checkA11y, injectAxe } from "axe-playwright";
 
 const pageUrls = ["/", "/about/"];
 
 for (const pageUrl of pageUrls) {
   test(`a11y page tests ${pageUrl}`, async ({ page }) => {
-    await page.goto(testLocation + pageUrl);
+    // Relative URL resolves against baseURL from playwright.config.js.
+    await page.goto(pageUrl);
     await injectAxe(page);
     await checkA11y(page, null, {
       detailedReport: true,


### PR DESCRIPTION
Fixes the two failing accessibility tests, and fixes the reason they were hard to diagnose.

## 1. The accessibility violation

Both tests failed on the same axe rule, `list` (serious):

```
List element has direct children that are not allowed: [role=presentation]
```

`site/_includes/layout.njk` put `role="presentation"` on the four main-nav `<li>` elements. That strips each item's implicit `listitem` role, so `<ul id="nav_list">` was left with four children that aren't list items — violating "`<ul>` and `<ol>` must only directly contain `<li>`, `<script>` or `<template>`".

**Impact:** screen readers didn't announce the main navigation as a list of four items, losing item count and position. Since `layout.njk` is the shared base layout, this affected **every page**, not just the two under test.

**Where it came from:** the CA state template uses this exact pattern for its tabs widget, where it's correct — `cagov.core.js` sets `role="tablist"` on the `<ul>` and `role="presentation"` on each `<li>`. A `tablist` isn't a list, so nothing breaks. Here it was applied to a plain nav `<ul>` with no replacement role, so the list semantics broke with nothing taking their place.

The fix is to drop the attribute. Nothing depends on it — CSS and JS target `.nav-item` / `.first-level-link`.

## 2. The suite was testing a different website

`test/index.spec.js` hardcoded `http://localhost:8080` and there was no Playwright `webServer` config, so it tested whatever was listening on 8080. On a dev machine running another CA.gov project (`eleventy --serve` defaults to 8080), that meant testing the wrong site entirely. Because those sites share the CA state template, the wrong target produced a near-identical `#nav_list` violation — so it silently looked plausible.

This PR adds `playwright.config.js` with:
- a `webServer` block that runs `npm run build` and serves `_dist/` on a dedicated port (8288), so `npm run test` is self-contained and no longer needs `npm run test:serve` first
- `baseURL`, so the spec uses relative paths instead of a hardcoded origin
- `reuseExistingServer: false`, so a busy port **fails loudly** rather than silently testing a foreign server

Also dropped an unused `expect` import and sorted the imports to satisfy `biome check`.

## Testing

Verified against `<title>Engaged California` on a known-free port:

| Code | Violations on `/` and `/about/` |
|---|---|
| `role="presentation"` present | 1 × `list` (serious) each |
| With this fix | 0 |

- `npm run test` → **2 passed**, "No accessibility violations detected!"
- Re-confirmed the suite still *catches* the violation: stashing just the `layout.njk` change makes both tests fail again, so this isn't passing by accident
- `npx @biomejs/biome check playwright.config.js test/index.spec.js` clean
- `npm run build` succeeds

## Note

Deliberately touches no `package.json` / `package-lock.json`, so this won't conflict with #152. The `webServer` command uses `npx --yes http-server`, matching what the existing `test:serve` script already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)